### PR TITLE
Record detail modal

### DIFF
--- a/lib/Onyx.css
+++ b/lib/Onyx.css
@@ -1,5 +1,6 @@
 .table {
   font-family: monospace;
+  font-size: 10pt;
   display: block;
   overflow-x: auto;
   overflow-y: scroll;

--- a/lib/Onyx.css
+++ b/lib/Onyx.css
@@ -1,4 +1,5 @@
 .table {
+  font-family: monospace;
   display: block;
   overflow-x: auto;
   overflow-y: scroll;
@@ -13,6 +14,10 @@
   position: sticky;
   top: 0px;
   margin: 0 0 0 0;
+}
+
+.table td {
+  vertical-align: middle
 }
 
 .card-header {

--- a/lib/Onyx.css
+++ b/lib/Onyx.css
@@ -2,9 +2,11 @@
   display: block;
   overflow-x: auto;
   overflow-y: scroll;
-  overscroll-behavior-x: none; 
+  overscroll-behavior: none; 
   height: 47vh;
   white-space: nowrap;
+  border-collapse: separate;
+  border-spacing: 0;
 }
 
 .table thead{

--- a/lib/Onyx.css
+++ b/lib/Onyx.css
@@ -13,7 +13,12 @@
 .table thead{
   position: sticky;
   top: 0px;
-  margin: 0 0 0 0;
+  /* margin: 0 0 0 0; */
+}
+
+.table th {
+  user-select: none;
+  cursor: pointer;
 }
 
 .table td {

--- a/lib/components/ErrorMessages.tsx
+++ b/lib/components/ErrorMessages.tsx
@@ -1,0 +1,20 @@
+import Alert from "react-bootstrap/Alert";
+import { ErrorType } from "../types";
+
+function ErrorMessages(props: { messages: ErrorType }) {
+  return Object.entries(props.messages).map(([key, value]) =>
+    Array.isArray(value) ? (
+      value.map((v: string) => (
+        <Alert key={key} variant="danger">
+          {key}: {v}
+        </Alert>
+      ))
+    ) : (
+      <Alert key={key} variant="danger">
+        {key}: {value}
+      </Alert>
+    )
+  );
+}
+
+export default ErrorMessages;

--- a/lib/components/Header.tsx
+++ b/lib/components/Header.tsx
@@ -64,7 +64,7 @@ function Header(props: HeaderProps) {
   return (
     <Navbar bg="dark" variant="dark" collapseOnSelect expand="sm">
       <Container fluid>
-        <Navbar.Brand>Onyx</Navbar.Brand>
+        <Navbar.Brand>⬗ Onyx</Navbar.Brand>
         <Navbar.Toggle aria-controls="responsive-navbar-nav" />
         <Navbar.Collapse id="responsive-navbar-nav">
           <Stack direction="horizontal" gap={3}>
@@ -105,7 +105,10 @@ function Header(props: HeaderProps) {
           <Form.Check
             type="switch"
             id="theme-switch"
-            label={<span className="text-light">Switch Theme</span>}
+            label={
+              <span className="text-light">{props.darkMode ? "☾" : "☼"} </span>
+            }
+            title={`Switch to ${props.darkMode ? "light mode" : "dark mode"}`}
             checked={props.darkMode}
             onChange={props.handleThemeChange}
           />

--- a/lib/components/LoadingAlert.tsx
+++ b/lib/components/LoadingAlert.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from "react";
 import Stack from "react-bootstrap/Stack";
 import Alert from "react-bootstrap/Alert";
 import { Spinner } from "react-bootstrap";
@@ -13,4 +14,24 @@ function LoadingAlert() {
   );
 }
 
-export default LoadingAlert;
+function DelayedLoadingAlert() {
+  const [showAlert, setShowAlert] = useState(false);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setShowAlert(true), 200);
+    return () => clearTimeout(timer);
+  });
+
+  return (
+    showAlert && (
+      <Alert variant="light">
+        <Stack direction="horizontal" gap={2}>
+          <Spinner />
+          <span>Loading...</span>
+        </Stack>
+      </Alert>
+    )
+  );
+}
+
+export { LoadingAlert, DelayedLoadingAlert };

--- a/lib/components/ResultsTable.tsx
+++ b/lib/components/ResultsTable.tsx
@@ -60,10 +60,32 @@ const ResultsTable = memo(function ResultsTable({
   function sortRows() {
     const sortIndex = headers().indexOf(sort.sortKey);
 
-    if (sort.direction === "asc") {
-      return sortedRows.sort((a, b) => (a[sortIndex] > b[sortIndex] ? 1 : -1));
-    } else if (sort.direction === "desc") {
-      return sortedRows.sort((a, b) => (a[sortIndex] < b[sortIndex] ? 1 : -1));
+    if (sortedRows.length > 0 && sort.direction === "asc") {
+      if (typeof sortedRows[0][sortIndex] === "number") {
+        return sortedRows.sort(
+          (a, b) => (a[sortIndex] as number) - (b[sortIndex] as number)
+        );
+      } else {
+        return sortedRows.sort((a, b) =>
+          (a[sortIndex] as string).toLowerCase() >
+          (b[sortIndex] as string).toLowerCase()
+            ? 1
+            : -1
+        );
+      }
+    } else if (sortedRows.length > 0 && sort.direction === "desc") {
+      if (typeof sortedRows[0][sortIndex] === "number") {
+        return sortedRows.sort(
+          (a, b) => (b[sortIndex] as number) - (a[sortIndex] as number)
+        );
+      } else {
+        return sortedRows.sort((a, b) =>
+          (a[sortIndex] as string).toLowerCase() <
+          (b[sortIndex] as string).toLowerCase()
+            ? 1
+            : -1
+        );
+      }
     } else {
       return rows;
     }

--- a/lib/components/ResultsTable.tsx
+++ b/lib/components/ResultsTable.tsx
@@ -11,7 +11,7 @@ const ResultsTable = memo(function ResultsTable({
 }: {
   data: ResultType[];
   titles?: Map<string, string>;
-  recordDetailHandler: (climbID: string) => void;
+  recordDetailHandler?: (climbID: string) => void;
   s3PathHandler?: (path: string) => void;
 }) {
   const headers = () => {
@@ -43,7 +43,7 @@ const ResultsTable = memo(function ResultsTable({
         {rows.map((row, index) => (
           <tr key={index}>
             {row.map((cell, index) =>
-              index === climbIDIndex ? (
+              recordDetailHandler && index === climbIDIndex ? (
                 <td key={index}>
                   <Button
                     variant="link"

--- a/lib/components/ResultsTable.tsx
+++ b/lib/components/ResultsTable.tsx
@@ -72,7 +72,7 @@ const ResultsTable = memo(function ResultsTable({
   const climbIDIndex = headers().indexOf("climb_id");
 
   return (
-    <Table striped bordered hover responsive size="sm">
+    <Table striped bordered hover responsive>
       <thead>
         <tr>
           {headers().map((header, index) => (
@@ -108,6 +108,7 @@ const ResultsTable = memo(function ResultsTable({
               typeof cell === "string" ? (
                 <td key={cellIndex}>
                   <Button
+                    size="sm"
                     variant="link"
                     onClick={() => {
                       recordDetailHandler(cell);
@@ -121,7 +122,11 @@ const ResultsTable = memo(function ResultsTable({
                 cell.startsWith("s3://") &&
                 cell.endsWith(".html") ? (
                 <td key={cellIndex}>
-                  <Button variant="link" onClick={() => s3PathHandler(cell)}>
+                  <Button
+                    size="sm"
+                    variant="link"
+                    onClick={() => s3PathHandler(cell)}
+                  >
                     {cell}
                   </Button>
                 </td>

--- a/lib/components/ResultsTable.tsx
+++ b/lib/components/ResultsTable.tsx
@@ -6,10 +6,12 @@ import { ResultType } from "../types";
 const ResultsTable = memo(function ResultsTable({
   data,
   titles,
+  recordDetailHandler,
   s3PathHandler,
 }: {
   data: ResultType[];
   titles?: Map<string, string>;
+  recordDetailHandler: (climbID: string) => void;
   s3PathHandler?: (path: string) => void;
 }) {
   const headers = () => {
@@ -19,6 +21,8 @@ const ResultsTable = memo(function ResultsTable({
       return [];
     }
   };
+
+  const climbIDIndex = headers().indexOf("climb_id");
 
   const rows = data.map((item) =>
     Object.values(item).map((value) => value?.toString().trim() || "")
@@ -39,9 +43,20 @@ const ResultsTable = memo(function ResultsTable({
         {rows.map((row, index) => (
           <tr key={index}>
             {row.map((cell, index) =>
-              s3PathHandler &&
-              cell.startsWith("s3://") &&
-              cell.endsWith(".html") ? (
+              index === climbIDIndex ? (
+                <td key={index}>
+                  <Button
+                    variant="link"
+                    onClick={() => {
+                      recordDetailHandler(cell);
+                    }}
+                  >
+                    {cell}
+                  </Button>
+                </td>
+              ) : s3PathHandler &&
+                cell.startsWith("s3://") &&
+                cell.endsWith(".html") ? (
                 <td key={index}>
                   <Button variant="link" onClick={() => s3PathHandler(cell)}>
                     {cell}

--- a/lib/pages/Data.tsx
+++ b/lib/pages/Data.tsx
@@ -330,6 +330,7 @@ function Results(props: ResultsProps) {
             titles={props.fieldDescriptions}
             recordDetailHandler={props.recordDetailHandler}
             s3PathHandler={props.s3PathHandler}
+            isSortable={!props.resultData?.next && !props.resultData?.previous}
           />
         )}
       </Container>
@@ -432,7 +433,7 @@ function RecordDetail(props: RecordDetailProps) {
                 id="uncontrolled-tab-example"
                 className="mb-3"
               >
-                <Tab eventKey="recordDetails" title="Record Details">
+                <Tab eventKey="recordDetails" title="Details">
                   <ResultsTable
                     data={
                       Object.entries(recordData.data)
@@ -449,6 +450,7 @@ function RecordDetail(props: RecordDetailProps) {
                 </Tab>
                 {Object.entries(recordData.data)
                   .filter(([, value]) => value instanceof Array)
+                  .sort()
                   .map(([key, value], index) => (
                     <Tab key={key} eventKey={index} title={key}>
                       <ResultsTable

--- a/lib/pages/Data.tsx
+++ b/lib/pages/Data.tsx
@@ -206,29 +206,24 @@ function Parameters(props: SearchProps) {
             <Container fluid className="panel p-2">
               <Stack gap={1}>
                 {filterList.map((filter, index) => (
-                  <div key={index}>
-                    <Filter
-                      project={props.project}
-                      httpPathHandler={props.httpPathHandler}
-                      filter={filter}
-                      fieldList={filterFieldOptions}
-                      projectFields={props.projectFields}
-                      typeLookups={props.typeLookups}
-                      fieldDescriptions={props.fieldDescriptions}
-                      lookupDescriptions={props.lookupDescriptions}
-                      handleFieldChange={(e) =>
-                        handleFilterFieldChange(e, index)
-                      }
-                      handleLookupChange={(e) =>
-                        handleFilterLookupChange(e, index)
-                      }
-                      handleValueChange={(e) =>
-                        handleFilterValueChange(e, index)
-                      }
-                      handleFilterAdd={() => handleFilterAdd(index + 1)}
-                      handleFilterRemove={() => handleFilterRemove(index)}
-                    />
-                  </div>
+                  <Filter
+                    key={index}
+                    project={props.project}
+                    httpPathHandler={props.httpPathHandler}
+                    filter={filter}
+                    fieldList={filterFieldOptions}
+                    projectFields={props.projectFields}
+                    typeLookups={props.typeLookups}
+                    fieldDescriptions={props.fieldDescriptions}
+                    lookupDescriptions={props.lookupDescriptions}
+                    handleFieldChange={(e) => handleFilterFieldChange(e, index)}
+                    handleLookupChange={(e) =>
+                      handleFilterLookupChange(e, index)
+                    }
+                    handleValueChange={(e) => handleFilterValueChange(e, index)}
+                    handleFilterAdd={() => handleFilterAdd(index + 1)}
+                    handleFilterRemove={() => handleFilterRemove(index)}
+                  />
                 ))}
               </Stack>
             </Container>
@@ -405,7 +400,6 @@ function RecordDetail(props: RecordDetailProps) {
       <Modal.Header closeButton>
         <Modal.Title id="contained-modal-title-vcenter">
           <Container fluid>
-            {" "}
             CLIMB ID: <code>{props.recordID}</code>
           </Container>
         </Modal.Title>
@@ -450,13 +444,17 @@ function RecordDetail(props: RecordDetailProps) {
                           Value: value,
                         })) as ResultType[]
                     }
+                    s3PathHandler={props.s3PathHandler}
                   />
                 </Tab>
                 {Object.entries(recordData.data)
                   .filter(([, value]) => value instanceof Array)
                   .map(([key, value], index) => (
-                    <Tab eventKey={index} title={key}>
-                      <ResultsTable data={value as ResultType[]} />
+                    <Tab key={key} eventKey={index} title={key}>
+                      <ResultsTable
+                        data={value as ResultType[]}
+                        s3PathHandler={props.s3PathHandler}
+                      />
                     </Tab>
                   ))}
               </Tabs>

--- a/lib/pages/Stats.tsx
+++ b/lib/pages/Stats.tsx
@@ -378,17 +378,20 @@ function GraphPanel(props: GraphPanelProps) {
     },
   };
 
-  const fields = props.graphFieldOptions.filter((field) =>
-    graphConfig[props.type as keyof typeof graphConfig].fields.includes(
-      getType(props.projectFields, field)
-    )
-  );
-
-  const groupBy = props.graphFieldOptions.filter((field) =>
-    graphConfig[props.type as keyof typeof graphConfig].groupBy.includes(
-      getType(props.projectFields, field)
-    )
-  );
+  let fields: string[] = [];
+  let groupBy: string[] = [];
+  if (props.type) {
+    fields = props.graphFieldOptions.filter((field) =>
+      graphConfig[props.type as keyof typeof graphConfig].fields.includes(
+        getType(props.projectFields, field)
+      )
+    );
+    groupBy = props.graphFieldOptions.filter((field) =>
+      graphConfig[props.type as keyof typeof graphConfig].groupBy.includes(
+        getType(props.projectFields, field)
+      )
+    );
+  }
 
   let g: JSX.Element;
 


### PR DESCRIPTION
## Added
- Added `ErrorMessages` component to generalise onyx error message display.
- Added `DelayedLoadingAlert` component, which can display a spinner after 0.2 seconds rather than instantly.
- Added `RecordDetail` component:
  - Any `climb_id` in a `ResultsTable` can now be clicked on.
  - This loads a modal for the record, with a tabbed interface displaying top-level information, as well as nested information, in sortable `ResultsTable` instances.

## Changed
- `ResultsTable` component changes:
  - Monospaced font, reduced text size, and increased cell size.
  - Removed overscroll behaviour.
  - Improved sticky column look.
  - Added sortable columns (currently for unpaginated data only).
- `Header` component changes:
  - Cleaned up light/dark toggle with unicode sun/moon symbols.
  - Added diamond symbol in brand name (because it looks cool).

## Fixed
- Fixed crash on adding graphs caused by previous fix in development.