### PR TITLE
Table upgrades ii, export improvements and more...

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,13 @@
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build package
+        run: |
+          npm install
+          npm run build

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,13 @@
+name: Lint
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Lint package
+        run: |
+          npm install
+          npm run lint

--- a/index.html
+++ b/index.html
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" style="height: 100vh">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" href="data:," />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Onyx: API for pathogen metadata</title>
   </head>
-  <body>
-    <div id="root"></div>
+  <body style="height: 100%">
+    <div id="root" style="height: 100%"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/lib/Onyx.css
+++ b/lib/Onyx.css
@@ -51,12 +51,12 @@
 }
 
 .onyx-parameters-panel-body {
-  height: 15vh;
+  height: 33vh;
   overflow-y: scroll;
 }
 
 .onyx-results-panel-body {
-  height: 52.4vh;
+  height: 78vh;
 }
 
 .onyx-graphs-panel-body {
@@ -88,4 +88,21 @@
 
 .onyx-modal-tab-pane {
   height: 70vh;
+}
+
+.parent {
+  display: flex;
+  width: 100%;
+}
+
+.left-col {
+  resize: horizontal;
+  overflow: auto;
+  min-width: 300px;
+  width: 300px;
+}
+
+.right-col {
+  flex-grow: 1;
+  min-width: 50%;
 }

--- a/lib/Onyx.css
+++ b/lib/Onyx.css
@@ -71,7 +71,6 @@
 .ag-theme-quartz {
   --ag-background-color: var(--bs-body-bg);
   --ag-foreground-color: var(--bs-body-color);
-  --ag-checkbox-unchecked-color: var(--bs-green);
   --ag-font-family: monospace;
 }
 

--- a/lib/Onyx.css
+++ b/lib/Onyx.css
@@ -50,20 +50,6 @@
   height: 50px;
 }
 
-.onyx-parameters-panel-body {
-  height: 33vh;
-  overflow-y: scroll;
-}
-
-.onyx-results-panel-body {
-  height: 78vh;
-}
-
-.onyx-graphs-panel-body {
-  height: 78vh;
-  overflow-y : scroll;
-}
-
 .onyx-text-pink {
   color: var(--bs-code-color);
 }

--- a/lib/Onyx.tsx
+++ b/lib/Onyx.tsx
@@ -150,7 +150,7 @@ function App(props: OnyxProps) {
   });
 
   return (
-    <Stack gap={2} className="Onyx">
+    <Stack gap={2} className="Onyx h-100">
       <Header
         {...props}
         projectName={projectInfoPending ? "Loading..." : projectName}
@@ -163,8 +163,8 @@ function App(props: OnyxProps) {
         handleThemeChange={() => setDarkMode(!darkMode)}
       />
       <Tab.Container activeKey={tabKey}>
-        <Tab.Content>
-          <Tab.Pane eventKey="data">
+        <Tab.Content className="h-100">
+          <Tab.Pane eventKey="data" className="h-100">
             <Data
               {...props}
               project={project}
@@ -174,7 +174,7 @@ function App(props: OnyxProps) {
               lookupDescriptions={lookupDescriptions}
             />
           </Tab.Pane>
-          <Tab.Pane eventKey="stats">
+          <Tab.Pane eventKey="stats" className="h-100">
             <Stats
               {...props}
               project={project}

--- a/lib/Onyx.tsx
+++ b/lib/Onyx.tsx
@@ -67,7 +67,7 @@ function App(props: OnyxProps) {
 
   // Set the first project as the default
   useEffect(() => {
-    if (!project && projects) {
+    if (!project && projects.length > 0) {
       setProject(projects[0]);
     }
   }, [project, projects]);

--- a/lib/Onyx.tsx
+++ b/lib/Onyx.tsx
@@ -38,7 +38,9 @@ function flattenFields(fields: Record<string, ProjectField>) {
 }
 
 function App(props: OnyxProps) {
-  const [darkMode, setDarkMode] = useState(false);
+  const [darkMode, setDarkMode] = useState(
+    localStorage.getItem("onyx-theme") === "dark"
+  );
   const [project, setProject] = useState("");
   const [tabKey, setTabKey] = useState("data");
 
@@ -47,6 +49,12 @@ function App(props: OnyxProps) {
     const htmlElement = document.querySelector("html");
     htmlElement?.setAttribute("data-bs-theme", darkMode ? "dark" : "light");
   }, [darkMode]);
+
+  const handleThemeChange = () => {
+    const darkModeChange = !darkMode;
+    setDarkMode(darkModeChange);
+    localStorage.setItem("onyx-theme", darkModeChange ? "dark" : "light");
+  };
 
   // Fetch the project list
   const { data: projects = [] } = useQuery({
@@ -160,7 +168,7 @@ function App(props: OnyxProps) {
         tabKey={tabKey}
         setTabKey={setTabKey}
         darkMode={darkMode}
-        handleThemeChange={() => setDarkMode(!darkMode)}
+        handleThemeChange={handleThemeChange}
       />
       <Tab.Container activeKey={tabKey}>
         <Tab.Content className="h-100">

--- a/lib/bootstrap.css
+++ b/lib/bootstrap.css
@@ -204,7 +204,6 @@
   color: var(--bs-body-color);
   text-align: var(--bs-body-text-align);
   background-color: var(--onyx-body-bg);
-  height: 90vh;
   -webkit-text-size-adjust: 100%;
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 }

--- a/lib/components/ExportModal.tsx
+++ b/lib/components/ExportModal.tsx
@@ -4,7 +4,7 @@ import Button from "react-bootstrap/Button";
 import InputGroup from "react-bootstrap/InputGroup";
 import Form from "react-bootstrap/Form";
 import ProgressBar from "react-bootstrap/ProgressBar";
-import { DataProps } from "../interfaces";
+import { DataProps, ExportHandlerProps } from "../interfaces";
 import { ExportStatus } from "../types";
 
 interface ExportModalProps extends DataProps {
@@ -13,12 +13,7 @@ interface ExportModalProps extends DataProps {
   defaultFileNamePrefix: string;
   fileExtension: string;
   exportProgressMessage: string;
-  handleExport: (
-    fileName: string,
-    statusToken: { status: ExportStatus },
-    setExportProgress: (exportProgress: number) => void,
-    setExportStatus: (exportStatus: ExportStatus) => void
-  ) => void;
+  handleExport: (exportProps: ExportHandlerProps) => void;
 }
 
 function useExportStatusToken() {
@@ -61,7 +56,12 @@ function ExportModal(props: ExportModalProps) {
     setExportProgress(0);
     readyExport();
     setExportStatus(ExportStatus.RUNNING);
-    props.handleExport(prefix, statusToken, setExportProgress, setExportStatus);
+    props.handleExport({
+      fileName: prefix + props.fileExtension,
+      statusToken,
+      setExportProgress,
+      setExportStatus,
+    });
   };
 
   const handleExportCancel = () => {
@@ -111,7 +111,8 @@ function ExportModal(props: ExportModalProps) {
             />
             <InputGroup.Text>{props.fileExtension}</InputGroup.Text>
             <Form.Control.Feedback type="invalid">
-              Name must be 5 to 50 alphanumeric, underscore or dash characters.
+              Prefix must be 5 to 50 alphanumeric, underscore or dash
+              characters.
             </Form.Control.Feedback>
             <Form.Text muted>
               <span>

--- a/lib/components/ExportModal.tsx
+++ b/lib/components/ExportModal.tsx
@@ -78,6 +78,7 @@ function ExportModal(props: ExportModalProps) {
 
   return (
     <Modal
+      className="onyx-modal"
       centered
       show={props.show}
       onHide={props.onHide}

--- a/lib/components/ExportModal.tsx
+++ b/lib/components/ExportModal.tsx
@@ -100,7 +100,7 @@ function ExportModal(props: ExportModalProps) {
               value={fileNamePrefix}
               placeholder={props.defaultFileNamePrefix}
               onChange={handleFileNamePrefixChange}
-              onKeyUp={(event) => {
+              onKeyDown={(event) => {
                 if (
                   event.key === "Enter" &&
                   props.defaultFileNamePrefix.startsWith(fileNamePrefix)

--- a/lib/components/ExportModal.tsx
+++ b/lib/components/ExportModal.tsx
@@ -1,0 +1,149 @@
+import { useState, useRef } from "react";
+import Modal from "react-bootstrap/Modal";
+import Button from "react-bootstrap/Button";
+import InputGroup from "react-bootstrap/InputGroup";
+import Form from "react-bootstrap/Form";
+import ProgressBar from "react-bootstrap/ProgressBar";
+import { DataProps } from "../interfaces";
+import { ExportStatus } from "../types";
+
+interface ExportModalProps extends DataProps {
+  show: boolean;
+  onHide: () => void;
+  defaultFileNamePrefix: string;
+  fileExtension: string;
+  exportProgressMessage: string;
+  handleExport: (
+    fileName: string,
+    statusToken: { status: ExportStatus },
+    setExportProgress: (exportProgress: number) => void,
+    setExportStatus: (exportStatus: ExportStatus) => void
+  ) => void;
+}
+
+function useExportStatusToken() {
+  const statusRef = useRef({ status: ExportStatus.READY });
+  const cancelExport = () =>
+    (statusRef.current.status = ExportStatus.CANCELLED);
+  const readyExport = () => (statusRef.current.status = ExportStatus.READY);
+  return {
+    statusToken: statusRef.current,
+    cancelExport,
+    readyExport,
+  };
+}
+
+function ExportModal(props: ExportModalProps) {
+  const [exportStatus, setExportStatus] = useState(ExportStatus.READY);
+  const [exportProgress, setExportProgress] = useState(0);
+  const [fileNamePrefix, setFileNamePrefix] = useState(
+    props.defaultFileNamePrefix
+  );
+  const { statusToken, readyExport, cancelExport } = useExportStatusToken();
+
+  const handleExportRunning = () => {
+    setExportProgress(0);
+    readyExport();
+    setExportStatus(ExportStatus.RUNNING);
+    props.handleExport(
+      fileNamePrefix.trim().replace(/\.csv$/, ""),
+      statusToken,
+      setExportProgress,
+      setExportStatus
+    );
+  };
+
+  const handleExportCancel = () => {
+    cancelExport();
+    setExportStatus(ExportStatus.CANCELLED);
+  };
+
+  return (
+    <Modal
+      centered
+      show={props.show}
+      onHide={props.onHide}
+      onExited={() => {
+        if (
+          exportStatus === ExportStatus.FINISHED ||
+          exportStatus === ExportStatus.CANCELLED
+        )
+          setExportStatus(ExportStatus.READY);
+      }}
+    >
+      <Modal.Header closeButton>
+        <Modal.Title>Export Data</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        {exportStatus === ExportStatus.READY && (
+          <InputGroup className="mb-3">
+            <InputGroup.Text>File Name</InputGroup.Text>
+            <Form.Control
+              placeholder={`${props.defaultFileNamePrefix}`}
+              onChange={(e) => setFileNamePrefix(e.target.value)}
+            />
+            <InputGroup.Text>{props.fileExtension}</InputGroup.Text>
+            <Form.Text muted>
+              <b>Warning:</b> If the file already exists, it will be
+              overwritten.
+            </Form.Text>
+          </InputGroup>
+        )}
+        {exportStatus === ExportStatus.RUNNING && (
+          <Form.Group className="mb-3">
+            <Form.Label className="d-flex justify-content-center">
+              {props.exportProgressMessage}
+            </Form.Label>
+            <ProgressBar now={exportProgress} />
+          </Form.Group>
+        )}
+        {exportStatus === ExportStatus.CANCELLED && (
+          <Form.Group className="mb-3">
+            <Form.Label className="d-flex justify-content-center">
+              Cancelled Operation.
+            </Form.Label>
+            <ProgressBar now={exportProgress} variant="danger" />
+          </Form.Group>
+        )}
+        {exportStatus === ExportStatus.FINISHED && (
+          <Form.Group className="mb-3">
+            <Form.Label className="d-flex justify-content-center">
+              Export Finished.
+            </Form.Label>
+            <ProgressBar now={exportProgress} />
+          </Form.Group>
+        )}
+      </Modal.Body>
+      <Modal.Footer>
+        <Button variant="dark" onClick={props.onHide}>
+          Close
+        </Button>
+        {exportStatus === ExportStatus.READY && (
+          <Button variant="primary" onClick={handleExportRunning}>
+            Export
+          </Button>
+        )}
+        {exportStatus === ExportStatus.RUNNING && (
+          <Button variant="danger" onClick={handleExportCancel}>
+            Cancel
+          </Button>
+        )}
+        {exportStatus === ExportStatus.CANCELLED && (
+          <Button
+            variant="primary"
+            onClick={() => setExportStatus(ExportStatus.READY)}
+          >
+            Retry
+          </Button>
+        )}
+        {exportStatus === ExportStatus.FINISHED && (
+          <Button variant="primary" onClick={props.onHide}>
+            Done
+          </Button>
+        )}
+      </Modal.Footer>
+    </Modal>
+  );
+}
+
+export default ExportModal;

--- a/lib/components/Filter.tsx
+++ b/lib/components/Filter.tsx
@@ -1,128 +1,178 @@
-import React from "react";
-import Container from "react-bootstrap/Container";
+import React, { useState } from "react";
+import Stack from "react-bootstrap/Stack";
+import CloseButton from "react-bootstrap/CloseButton";
 import Row from "react-bootstrap/Row";
 import Col from "react-bootstrap/Col";
-import Stack from "react-bootstrap/Stack";
 import Button from "react-bootstrap/Button";
 import { Dropdown, Choice, MultiChoice } from "./Dropdowns";
 import { Input, MultiInput } from "./Inputs";
+import { FilterField } from "../types";
 import { DataProps } from "../interfaces";
 
 interface FilterProps extends DataProps {
-  filter: { field: string; lookup: string; value: string };
+  index: number;
+  filterList: FilterField[];
+  setFilterList: (value: FilterField[]) => void;
   fieldList: string[];
-  handleFieldChange: React.ChangeEventHandler<HTMLSelectElement>;
-  handleLookupChange: React.ChangeEventHandler<HTMLSelectElement>;
-  handleValueChange: React.ChangeEventHandler<
-    HTMLInputElement | HTMLSelectElement
-  >;
-  handleFilterAdd: () => void;
-  handleFilterRemove: () => void;
+  setEditMode: (value: boolean) => void;
 }
 
 function Filter(props: FilterProps) {
+  const [filter, setFilter] = useState(props.filterList[props.index]);
+
+  const handleFieldChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const updatedFilter = { ...filter };
+    updatedFilter.field = e.target.value;
+    updatedFilter.lookup =
+      props.typeLookups.get(
+        props.projectFields.get(e.target.value)?.type || ""
+      )?.[0] || "";
+
+    if (updatedFilter.lookup === "isnull") {
+      updatedFilter.value = "true";
+    } else {
+      updatedFilter.value = "";
+    }
+    setFilter(updatedFilter);
+  };
+
+  const handleLookupChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const updatedFilter = { ...filter };
+    updatedFilter.lookup = e.target.value;
+
+    if (updatedFilter.lookup === "isnull") {
+      updatedFilter.value = "true";
+    } else {
+      updatedFilter.value = "";
+    }
+    setFilter(updatedFilter);
+  };
+
+  const handleValueChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>
+  ) => {
+    const updatedFilter = { ...filter };
+    updatedFilter.value = e.target.value;
+    setFilter(updatedFilter);
+  };
+
+  const handleApply = () => {
+    props.setFilterList([
+      ...props.filterList.slice(0, props.index),
+      filter,
+      ...props.filterList.slice(props.index + 1),
+    ]);
+    props.setEditMode(false);
+  };
+
   let f: JSX.Element;
   const getValueList = (v: string) => {
     return v ? v.split(",") : [];
   };
 
-  if (props.filter.lookup === "isnull") {
+  if (filter.lookup === "isnull") {
     f = (
       <Dropdown
         options={["true", "false"]}
-        value={props.filter.value}
-        onChange={props.handleValueChange}
+        value={filter.value}
+        onChange={handleValueChange}
       />
     );
-  } else if (props.projectFields.get(props.filter.field)?.type === "choice") {
-    if (props.filter.lookup.endsWith("in")) {
+  } else if (props.projectFields.get(filter.field)?.type === "choice") {
+    if (filter.lookup.endsWith("in")) {
       f = (
         <MultiChoice
           project={props.project}
-          field={props.filter.field}
+          field={filter.field}
           httpPathHandler={props.httpPathHandler}
-          options={props.projectFields.get(props.filter.field)?.values || []}
-          value={getValueList(props.filter.value)}
-          onChange={props.handleValueChange}
+          options={props.projectFields.get(filter.field)?.values || []}
+          value={getValueList(filter.value)}
+          onChange={handleValueChange}
         />
       );
     } else {
       f = (
         <Choice
           project={props.project}
-          field={props.filter.field}
+          field={filter.field}
           httpPathHandler={props.httpPathHandler}
           isClearable
-          options={props.projectFields.get(props.filter.field)?.values || []}
-          value={props.filter.value}
-          onChange={props.handleValueChange}
+          options={props.projectFields.get(filter.field)?.values || []}
+          value={filter.value}
+          onChange={handleValueChange}
         />
       );
     }
-  } else if (props.filter.lookup.endsWith("in")) {
+  } else if (filter.lookup.endsWith("in")) {
     f = (
       <MultiInput
-        value={getValueList(props.filter.value)}
-        onChange={props.handleValueChange}
+        value={getValueList(filter.value)}
+        onChange={handleValueChange}
       />
     );
-  } else if (props.filter.lookup.endsWith("range")) {
+  } else if (filter.lookup.endsWith("range")) {
     f = (
       <MultiInput
-        value={getValueList(props.filter.value)}
+        value={getValueList(filter.value)}
         limit={2}
-        onChange={props.handleValueChange}
+        onChange={handleValueChange}
       />
     );
-  } else if (props.projectFields.get(props.filter.field)?.type === "bool") {
+  } else if (props.projectFields.get(filter.field)?.type === "bool") {
     f = (
       <Dropdown
         isClearable
         options={["true", "false"]}
-        value={props.filter.value}
-        onChange={props.handleValueChange}
+        value={filter.value}
+        onChange={handleValueChange}
       />
     );
   } else {
-    f = <Input value={props.filter.value} onChange={props.handleValueChange} />;
+    f = <Input value={filter.value} onChange={handleValueChange} />;
   }
   return (
-    <Stack direction="horizontal" gap={1}>
-      <Container fluid className="g-0">
-        <Row className="g-1">
-          <Col sm={6} lg={4}>
-            <Dropdown
-              options={props.fieldList}
-              titles={props.fieldDescriptions}
-              value={props.filter.field}
-              placeholder="Select field..."
-              onChange={props.handleFieldChange}
-            />
-          </Col>
-          <Col sm={6} lg={4}>
-            <Dropdown
-              options={
-                props.typeLookups.get(
-                  props.projectFields.get(props.filter.field)?.type || ""
-                ) || []
-              }
-              titles={props.lookupDescriptions}
-              value={props.filter.lookup}
-              placeholder="Select lookup..."
-              onChange={props.handleLookupChange}
-            />
-          </Col>
-          <Col sm={12} lg={4}>
-            {f}
-          </Col>
-        </Row>
-      </Container>
-      <Button variant="dark" onClick={props.handleFilterAdd}>
-        +
-      </Button>
-      <Button variant="dark" onClick={props.handleFilterRemove}>
-        -
-      </Button>
+    <Stack gap={1} className="p-1">
+      <Row>
+        <Col>
+          <h5>Edit Filter</h5>
+        </Col>
+        <Col>
+          <CloseButton
+            className="float-end"
+            onClick={() => props.setEditMode(false)}
+          />
+        </Col>
+      </Row>
+      <hr />
+      <Dropdown
+        options={props.fieldList}
+        titles={props.fieldDescriptions}
+        value={filter.field}
+        placeholder="Select field..."
+        onChange={handleFieldChange}
+      />
+      <Dropdown
+        options={
+          props.typeLookups.get(
+            props.projectFields.get(filter.field)?.type || ""
+          ) || []
+        }
+        titles={props.lookupDescriptions}
+        value={filter.lookup}
+        placeholder="Select lookup..."
+        onChange={handleLookupChange}
+      />
+      {f}
+      <hr />
+      <Stack direction="horizontal" gap={1}>
+        <div className="me-auto"></div>
+        <Button variant="dark" onClick={handleApply}>
+          Apply
+        </Button>
+        <Button variant="dark" onClick={() => props.setEditMode(false)}>
+          Cancel
+        </Button>
+      </Stack>
     </Stack>
   );
 }

--- a/lib/components/FilterPanel.tsx
+++ b/lib/components/FilterPanel.tsx
@@ -102,7 +102,7 @@ function FilterPanel(props: FilterPanelProps) {
   };
 
   return (
-    <Card>
+    <Card className="h-50">
       <Card.Header>
         <span>Filters</span>
         <Stack direction="horizontal" gap={1} className="float-end">
@@ -118,7 +118,7 @@ function FilterPanel(props: FilterPanelProps) {
           </Button>
         </Stack>
       </Card.Header>
-      <Container fluid className="onyx-parameters-panel-body p-2">
+      <Container fluid className="overflow-y-scroll p-2 h-100">
         {editMode ? (
           <Filter
             {...props}

--- a/lib/components/QueryHandler.tsx
+++ b/lib/components/QueryHandler.tsx
@@ -12,31 +12,35 @@ function LoadingSpinner() {
     return () => clearTimeout(timer);
   });
 
-  return (
-    showAlert && (
-      <div className="d-flex justify-content-center">
-        <Stack direction="horizontal" gap={2}>
-          <Spinner />
-          <span>Loading...</span>
-        </Stack>
-      </div>
-    )
+  return showAlert ? (
+    <div className="d-flex justify-content-center">
+      <Stack direction="horizontal" gap={2}>
+        <Spinner />
+        <span>Loading...</span>
+      </Stack>
+    </div>
+  ) : (
+    <></>
   );
 }
 
 function ErrorMessages(props: { messages: ErrorType }) {
-  return Object.entries(props.messages).map(([key, value]) =>
-    Array.isArray(value) ? (
-      value.map((v: string) => (
-        <Alert key={key} variant="danger">
-          {key}: {v}
-        </Alert>
-      ))
-    ) : (
-      <Alert key={key} variant="danger">
-        {key}: {value}
-      </Alert>
-    )
+  return (
+    <>
+      {Object.entries(props.messages).map(([key, value]) =>
+        Array.isArray(value) ? (
+          value.map((v: string) => (
+            <Alert key={key} variant="danger">
+              {key}: {v}
+            </Alert>
+          ))
+        ) : (
+          <Alert key={key} variant="danger">
+            {key}: {value}
+          </Alert>
+        )
+      )}
+    </>
   );
 }
 

--- a/lib/components/RecordModal.tsx
+++ b/lib/components/RecordModal.tsx
@@ -134,7 +134,7 @@ function RecordData(props: RecordModalProps) {
           onHide={() => setExportModalShow(false)}
           exportProgressMessage={"Exporting record data to JSON..."}
         />
-        <Row style={{ height: "100%" }}>
+        <Row className="h-100">
           <Col xs={3} xl={2}>
             <Stack gap={1}>
               <hr />
@@ -180,11 +180,8 @@ function RecordData(props: RecordModalProps) {
             </Stack>
           </Col>
           <Col xs={9} xl={10}>
-            <Tab.Content style={{ height: "100%" }}>
-              <Tab.Pane
-                eventKey="record-data-details"
-                style={{ height: "100%" }}
-              >
+            <Tab.Content className="h-100">
+              <Tab.Pane eventKey="record-data-details" className="h-100">
                 <h5>Details</h5>
                 <Table
                   {...props}
@@ -202,7 +199,7 @@ function RecordData(props: RecordModalProps) {
                 />
               </Tab.Pane>
               {relationFields.map(([key, value]) => (
-                <Tab.Pane key={key} eventKey={key} style={{ height: "100%" }}>
+                <Tab.Pane key={key} eventKey={key} className="h-100">
                   <h5>{formatTitle(key)}</h5>
                   <Table
                     {...props}

--- a/lib/components/RecordModal.tsx
+++ b/lib/components/RecordModal.tsx
@@ -198,6 +198,7 @@ function RecordData(props: RecordModalProps) {
                       })),
                     } as unknown as ResultData
                   }
+                  defaultFileNamePrefix={`${props.recordID}_details`}
                   footer="Table showing the top-level fields for the record."
                   cellRenderers={new Map([["Value", DetailCellRenderer]])}
                 />
@@ -208,6 +209,7 @@ function RecordData(props: RecordModalProps) {
                   <Table
                     {...props}
                     data={{ data: value } as ResultData}
+                    defaultFileNamePrefix={`${props.recordID}_${key}`}
                     headerTooltips={props.fieldDescriptions}
                     headerTooltipPrefix={key + "__"}
                     footer={
@@ -319,6 +321,7 @@ function RecordHistory(props: RecordModalProps) {
         <Table
           {...props}
           data={{ data: recordHistory.data?.history } as ResultData}
+          defaultFileNamePrefix={`${props.recordID}_history`}
           flexOnly={["changes"]}
           tooltipFields={["timestamp"]}
           headerNames={

--- a/lib/components/RecordModal.tsx
+++ b/lib/components/RecordModal.tsx
@@ -85,9 +85,9 @@ function RecordData(props: RecordModalProps) {
     ([key]) => props.projectFields.get(key)?.type !== "relation"
   );
 
-  const relationFields = Object.entries(recordData.data).filter(
-    ([key]) => props.projectFields.get(key)?.type === "relation"
-  );
+  const relationFields = Object.entries(recordData.data)
+    .filter(([key]) => props.projectFields.get(key)?.type === "relation")
+    .sort(([key1], [key2]) => (key1 < key2 ? -1 : 1));
 
   return (
     <QueryHandler

--- a/lib/components/RecordModal.tsx
+++ b/lib/components/RecordModal.tsx
@@ -49,6 +49,30 @@ function RecordDataField({
 function RecordData(props: RecordModalProps) {
   const [showExportToast, setShowExportToast] = useState(false);
 
+  const DetailCellRenderer = (cellRendererProps: CustomCellRendererProps) => {
+    if (
+      props.s3PathHandler &&
+      typeof cellRendererProps.value === "string" &&
+      cellRendererProps.value.startsWith("s3://") &&
+      cellRendererProps.value.endsWith(".html")
+    ) {
+      return (
+        <Button
+          className="p-0"
+          size="sm"
+          variant="link"
+          onClick={() =>
+            props.s3PathHandler && props.s3PathHandler(cellRendererProps.value)
+          }
+        >
+          {cellRendererProps.value}
+        </Button>
+      );
+    } else {
+      return cellRendererProps.value;
+    }
+  };
+
   // Fetch record data, depending on project and record ID
   const {
     isFetching: recordDataPending,
@@ -175,6 +199,7 @@ function RecordData(props: RecordModalProps) {
                     } as unknown as ResultData
                   }
                   footer="Table showing the top-level fields for the record."
+                  cellRenderers={new Map([["Value", DetailCellRenderer]])}
                 />
               </Tab.Pane>
               {relationFields.map(([key, value]) => (

--- a/lib/components/RecordModal.tsx
+++ b/lib/components/RecordModal.tsx
@@ -165,6 +165,7 @@ function RecordData(props: RecordModalProps) {
               >
                 <h5>Details</h5>
                 <Table
+                  {...props}
                   data={
                     {
                       data: detailFields.map(([key, value]) => ({
@@ -173,7 +174,6 @@ function RecordData(props: RecordModalProps) {
                       })),
                     } as unknown as ResultData
                   }
-                  s3PathHandler={props.s3PathHandler}
                   footer="Table showing the top-level fields for the record."
                 />
               </Tab.Pane>
@@ -181,10 +181,10 @@ function RecordData(props: RecordModalProps) {
                 <Tab.Pane key={key} eventKey={key} style={{ height: "100%" }}>
                   <h5>{formatTitle(key)}</h5>
                   <Table
+                    {...props}
                     data={{ data: value } as ResultData}
                     headerTooltips={props.fieldDescriptions}
                     headerTooltipPrefix={key + "__"}
-                    s3PathHandler={props.s3PathHandler}
                     footer={
                       props.fieldDescriptions.get(key) || "No Description."
                     }
@@ -292,6 +292,7 @@ function RecordHistory(props: RecordModalProps) {
       <>
         <h5>History</h5>
         <Table
+          {...props}
           data={{ data: recordHistory.data?.history } as ResultData}
           flexOnly={["changes"]}
           tooltipFields={["timestamp"]}

--- a/lib/components/ResultsPanel.tsx
+++ b/lib/components/ResultsPanel.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import Container from "react-bootstrap/Container";
 import Card from "react-bootstrap/Card";
 import Table from "./Table";
@@ -15,7 +16,24 @@ interface ResultsPanelProps extends DataProps {
   handleRecordModalShow: (climbID: string) => void;
 }
 
+function getDefaultFileNamePrefix(project: string, searchParameters: string) {
+  // Create the default file name prefix based on the project and search parameters
+  // Use only the values of the search parameters, and limit to 20 characters
+  return [["", project]]
+    .concat(Array.from(new URLSearchParams(searchParameters).entries()))
+    .map(([, value]) => value)
+    .map((value) => value.split(",").map((v) => v.replace(/[\W_]+/g, "")))
+    .flat()
+    .join("_")
+    .slice(0, 50);
+}
+
 function ResultsPanel(props: ResultsPanelProps) {
+  const defaultFileNamePrefix = useMemo(
+    () => getDefaultFileNamePrefix(props.project, props.searchParameters),
+    [props.project, props.searchParameters]
+  );
+
   return (
     <Card>
       <Card.Header>Results</Card.Header>
@@ -29,6 +47,7 @@ function ResultsPanel(props: ResultsPanelProps) {
             <Table
               {...props}
               data={props.resultData || {}}
+              defaultFileNamePrefix={defaultFileNamePrefix}
               headerTooltips={props.fieldDescriptions}
               handleRecordModalShow={props.handleRecordModalShow}
             />
@@ -36,6 +55,7 @@ function ResultsPanel(props: ResultsPanelProps) {
             <ServerPaginatedTable
               {...props}
               searchParameters={props.searchParameters}
+              defaultFileNamePrefix={defaultFileNamePrefix}
               data={props.resultData || {}}
               headerTooltips={props.fieldDescriptions}
               handleRecordModalShow={props.handleRecordModalShow}

--- a/lib/components/ResultsPanel.tsx
+++ b/lib/components/ResultsPanel.tsx
@@ -42,6 +42,29 @@ function formatResultData(resultData: ResultData) {
   );
 }
 
+// async function getAllResultData(
+//   project: string,
+//   resultData: ResultData,
+//   httpPathHandler: (path: string) => Promise<Response>
+// ) {
+//   const allResultData = formatResultData(resultData);
+//   let nextParams = resultData.next?.split("?", 2)[1] || "";
+
+//   while (nextParams) {
+//     const search = new URLSearchParams(nextParams);
+//     const data = httpPathHandler(
+//       `projects/${project}/?${search.toString()}`
+//     ).then((response) => response.json());
+
+//     await data.then((result) => {
+//       allResultData.concat(formatResultData(result));
+//       nextParams = result.next?.split("?", 2)[1] || "";
+//     });
+//   }
+
+//   return allResultData;
+// }
+
 function ResultsPanel(props: ResultsPanelProps) {
   const [showExportToast, setShowExportToast] = useState(false);
 
@@ -73,7 +96,7 @@ function ResultsPanel(props: ResultsPanelProps) {
           className="float-end"
           size="sm"
           disabled={!props.fileWriter}
-          variant="success"
+          variant="dark"
           onClick={handleExportToCSV}
         >
           Export Page to CSV

--- a/lib/components/ResultsPanel.tsx
+++ b/lib/components/ResultsPanel.tsx
@@ -18,11 +18,13 @@ interface ResultsPanelProps extends DataProps {
 
 function getDefaultFileNamePrefix(project: string, searchParameters: string) {
   // Create the default file name prefix based on the project and search parameters
-  // Use the underscore+alphanumeric characters of the search values, and limits prefix to 50 characters
+  // Uses filter/search values only, replaces commas and spaces with underscores,
+  // removes special characters, and truncates to 50 characters
   return [["", project]]
     .concat(Array.from(new URLSearchParams(searchParameters).entries()))
-    .map(([, value]) => value)
-    .map((value) => value.split(",").map((v) => v.replace(/[\W_]+/g, "")))
+    .map(([, value]) =>
+      value.split(/[ ,]+/).map((v) => v.replace(/[^a-zA-Z0-9_/-]/, ""))
+    )
     .flat()
     .join("_")
     .slice(0, 50);

--- a/lib/components/ResultsPanel.tsx
+++ b/lib/components/ResultsPanel.tsx
@@ -18,7 +18,7 @@ interface ResultsPanelProps extends DataProps {
 
 function getDefaultFileNamePrefix(project: string, searchParameters: string) {
   // Create the default file name prefix based on the project and search parameters
-  // Use only the values of the search parameters, and limit to 20 characters
+  // Use the underscore+alphanumeric characters of the search values, and limits prefix to 50 characters
   return [["", project]]
     .concat(Array.from(new URLSearchParams(searchParameters).entries()))
     .map(([, value]) => value)

--- a/lib/components/ResultsPanel.tsx
+++ b/lib/components/ResultsPanel.tsx
@@ -12,7 +12,6 @@ interface ResultsPanelProps extends DataProps {
   resultError: Error | null;
   resultData: ResultData;
   searchParameters: string;
-  setSearchParameters: (params: string) => void;
   handleRecordModalShow: (climbID: string) => void;
 }
 

--- a/lib/components/ResultsPanel.tsx
+++ b/lib/components/ResultsPanel.tsx
@@ -1,9 +1,5 @@
-import { useState } from "react";
 import Container from "react-bootstrap/Container";
-import Button from "react-bootstrap/Button";
 import Card from "react-bootstrap/Card";
-import Toast from "react-bootstrap/Toast";
-import { mkConfig, generateCsv, asString } from "export-to-csv";
 import Table from "./Table";
 import { ServerPaginatedTable } from "./Table";
 import QueryHandler from "./QueryHandler";
@@ -16,111 +12,13 @@ interface ResultsPanelProps extends DataProps {
   resultData: ResultData;
   searchParameters: string;
   setSearchParameters: (params: string) => void;
-  pageNumber: number;
-  setPageNumber: (page: number) => void;
   handleRecordModalShow: (climbID: string) => void;
 }
 
-function formatResultData(resultData: ResultData) {
-  // For CSV export, we allow string, number and boolean values
-  // All other types are converted to strings
-  return (
-    resultData.data?.map((row) =>
-      Object.fromEntries(
-        Object.entries(row).map(([key, value]) => [
-          key,
-          typeof value === "string" ||
-          typeof value === "number" ||
-          typeof value === "boolean"
-            ? value
-            : value === null
-            ? ""
-            : JSON.stringify(value),
-        ])
-      )
-    ) || []
-  );
-}
-
-// async function getAllResultData(
-//   project: string,
-//   resultData: ResultData,
-//   httpPathHandler: (path: string) => Promise<Response>
-// ) {
-//   const allResultData = formatResultData(resultData);
-//   let nextParams = resultData.next?.split("?", 2)[1] || "";
-
-//   while (nextParams) {
-//     const search = new URLSearchParams(nextParams);
-//     const data = httpPathHandler(
-//       `projects/${project}/?${search.toString()}`
-//     ).then((response) => response.json());
-
-//     await data.then((result) => {
-//       allResultData.concat(formatResultData(result));
-//       nextParams = result.next?.split("?", 2)[1] || "";
-//     });
-//   }
-
-//   return allResultData;
-// }
-
 function ResultsPanel(props: ResultsPanelProps) {
-  const [showExportToast, setShowExportToast] = useState(false);
-
-  const fileName = `${props.project}${
-    props.pageNumber > 1 ? "_" + props.pageNumber.toString() : ""
-  }`;
-
-  const csvConfig = mkConfig({
-    filename: fileName,
-    useKeysAsHeaders: true,
-  });
-
-  const handleExportToCSV = () => {
-    const csvData = asString(
-      generateCsv(csvConfig)(formatResultData(props.resultData))
-    );
-
-    if (props.fileWriter) {
-      setShowExportToast(true);
-      props.fileWriter(fileName + ".csv", csvData);
-    }
-  };
-
   return (
     <Card>
-      <Card.Header>
-        <span>Results</span>
-        <Button
-          className="float-end"
-          size="sm"
-          disabled={!props.fileWriter}
-          variant="dark"
-          onClick={handleExportToCSV}
-        >
-          Export Page to CSV
-        </Button>
-        <Toast
-          onClose={() => setShowExportToast(false)}
-          show={showExportToast}
-          delay={3000}
-          autohide
-          style={{
-            position: "absolute",
-            top: 50,
-            right: 15,
-            zIndex: 9999,
-          }}
-        >
-          <Toast.Header>
-            <strong className="me-auto">Export Started</strong>
-          </Toast.Header>
-          <Toast.Body>
-            File: <strong>{fileName}.csv</strong>
-          </Toast.Body>
-        </Toast>
-      </Card.Header>
+      <Card.Header>Results</Card.Header>
       <Container fluid className="onyx-results-panel-body p-2 pb-0">
         <QueryHandler
           isFetching={props.resultPending}

--- a/lib/components/ResultsPanel.tsx
+++ b/lib/components/ResultsPanel.tsx
@@ -129,20 +129,18 @@ function ResultsPanel(props: ResultsPanelProps) {
         >
           {props.searchParameters.includes("summarise=") ? (
             <Table
+              {...props}
               data={props.resultData || {}}
               headerTooltips={props.fieldDescriptions}
               handleRecordModalShow={props.handleRecordModalShow}
-              s3PathHandler={props.s3PathHandler}
             />
           ) : (
             <ServerPaginatedTable
-              project={props.project}
-              data={props.resultData || {}}
+              {...props}
               searchParameters={props.searchParameters}
+              data={props.resultData || {}}
               headerTooltips={props.fieldDescriptions}
               handleRecordModalShow={props.handleRecordModalShow}
-              httpPathHandler={props.httpPathHandler}
-              s3PathHandler={props.s3PathHandler}
             />
           )}
         </QueryHandler>

--- a/lib/components/ResultsPanel.tsx
+++ b/lib/components/ResultsPanel.tsx
@@ -5,6 +5,7 @@ import Card from "react-bootstrap/Card";
 import Toast from "react-bootstrap/Toast";
 import { mkConfig, generateCsv, asString } from "export-to-csv";
 import Table from "./Table";
+import { ServerPaginatedTable } from "./Table";
 import QueryHandler from "./QueryHandler";
 import { ResultData } from "../types";
 import { DataProps } from "../interfaces";
@@ -103,18 +104,24 @@ function ResultsPanel(props: ResultsPanelProps) {
           error={props.resultError}
           data={props.resultData}
         >
-          <Table
-            project={props.project}
-            data={props.resultData || {}}
-            searchParameters={props.searchParameters}
-            headerTooltips={props.fieldDescriptions}
-            handleRecordModalShow={props.handleRecordModalShow}
-            httpPathHandler={props.httpPathHandler}
-            s3PathHandler={props.s3PathHandler}
-            isServerData={
-              !(!props.resultData?.next && !props.resultData?.previous)
-            }
-          />
+          {props.searchParameters.includes("summarise=") ? (
+            <Table
+              data={props.resultData || {}}
+              headerTooltips={props.fieldDescriptions}
+              handleRecordModalShow={props.handleRecordModalShow}
+              s3PathHandler={props.s3PathHandler}
+            />
+          ) : (
+            <ServerPaginatedTable
+              project={props.project}
+              data={props.resultData || {}}
+              searchParameters={props.searchParameters}
+              headerTooltips={props.fieldDescriptions}
+              handleRecordModalShow={props.handleRecordModalShow}
+              httpPathHandler={props.httpPathHandler}
+              s3PathHandler={props.s3PathHandler}
+            />
+          )}
         </QueryHandler>
       </Container>
     </Card>

--- a/lib/components/ResultsPanel.tsx
+++ b/lib/components/ResultsPanel.tsx
@@ -36,9 +36,9 @@ function ResultsPanel(props: ResultsPanelProps) {
   );
 
   return (
-    <Card>
+    <Card className="h-100">
       <Card.Header>Results</Card.Header>
-      <Container fluid className="onyx-results-panel-body p-2 pb-0">
+      <Container fluid className="p-2 pb-0 h-100">
         <QueryHandler
           isFetching={props.resultPending}
           error={props.resultError}

--- a/lib/components/Table.tsx
+++ b/lib/components/Table.tsx
@@ -26,26 +26,6 @@ import { DataProps } from "../interfaces";
 
 ModuleRegistry.registerModules([ClientSideRowModelModule]);
 
-interface TablePaginationProps {
-  isPaginated: boolean;
-  paginationParams: {
-    pageCountMessage: string;
-    pageNumber: number;
-    numPages: number;
-    prevPage: boolean;
-    nextPage: boolean;
-    prevParams: string;
-    nextParams: string;
-    handleUserPageChange: (params: string, userPage: number) => void;
-  };
-}
-
-interface TableOptionsProps extends DataProps {
-  gridRef: React.RefObject<AgGridReact<Record<string, string | number>>>;
-  isFilterable: boolean;
-  handleExportToCSV: () => void;
-}
-
 interface BaseTableProps extends DataProps {
   rowData: Record<string, string | number>[];
   columnDefs: ColDef[];
@@ -66,6 +46,11 @@ interface BaseTableProps extends DataProps {
     nextParams: string;
     handleUserPageChange: (params: string, userPage: number) => void;
   };
+}
+
+interface TableOptionsProps extends BaseTableProps {
+  gridRef: React.RefObject<AgGridReact<Record<string, string | number>>>;
+  handleExportToCSV: () => void;
 }
 
 interface TableProps extends DataProps {
@@ -124,7 +109,7 @@ function formatResultData(resultData: ResultData) {
 //   );
 // }
 
-function TablePagination(props: TablePaginationProps) {
+function TablePagination(props: BaseTableProps) {
   return (
     <Pagination size="sm">
       <Pagination.First
@@ -219,6 +204,13 @@ function TableOptions(props: TableOptionsProps) {
           Clear Table Filters
         </Dropdown.Item>
         <DropdownDivider />
+        <Dropdown.Header> Page Size </Dropdown.Header>
+        {[10, 50, 100, 500, 1000].map((size) => (
+          <Dropdown.Item
+            key={`pageSize${size}`}
+            disabled={!props.isPaginated}
+          >{`${size} rows`}</Dropdown.Item>
+        ))}
         <Dropdown.Header>Export Data</Dropdown.Header>
         <Dropdown.Item
           key="exportToCSV"

--- a/lib/components/Table.tsx
+++ b/lib/components/Table.tsx
@@ -1,10 +1,9 @@
-import { useState, useCallback, useMemo } from "react";
+import { useState, useCallback, useMemo, useRef } from "react";
 import { AgGridReact, CustomCellRendererProps } from "@ag-grid-community/react"; // React Data Grid Component
 import "@ag-grid-community/styles/ag-grid.css"; // Mandatory CSS required by the Data Grid
 import "@ag-grid-community/styles/ag-theme-quartz.min.css"; // Optional Theme applied to the Data Grid
 import { ClientSideRowModelModule } from "@ag-grid-community/client-side-row-model";
 import {
-  GridOptions,
   ColDef,
   SortChangedEvent,
   ModuleRegistry,
@@ -12,7 +11,8 @@ import {
 } from "@ag-grid-community/core";
 import { useQuery } from "@tanstack/react-query";
 import Button from "react-bootstrap/Button";
-import { Container, Pagination } from "react-bootstrap";
+import Container from "react-bootstrap/Container";
+import Pagination from "react-bootstrap/Pagination";
 import Stack from "react-bootstrap/Stack";
 import { ResultData, ResultType } from "../types";
 
@@ -37,69 +37,34 @@ function formatResultData(resultData: ResultData) {
   );
 }
 
-function urlToParams(url: string) {
-  return url.split("?", 2)[1];
-}
-
 function Table({
-  project,
   data,
-  searchParameters,
   headerNames,
   headerTooltips,
   headerTooltipPrefix = "",
   tooltipFields,
   flexOnly,
-  isServerData = false,
   footer = "",
   cellRenderers,
   handleRecordModalShow,
-  httpPathHandler,
   s3PathHandler,
 }: {
   data: ResultData;
-  project?: string;
-  searchParameters?: string;
   headerNames?: Map<string, string>;
   headerTooltips?: Map<string, string>;
   headerTooltipPrefix?: string;
   tooltipFields?: string[];
   flexOnly?: string[];
-  isServerData?: boolean;
   footer?: string;
   cellRenderers?: Map<string, (params: CustomCellRendererProps) => JSX.Element>;
   handleRecordModalShow?: (climbID: string) => void;
-  httpPathHandler?: (path: string) => Promise<Response>;
   s3PathHandler?: (path: string) => void;
 }) {
+  const gridRef = useRef<AgGridReact<ResultType>>(null);
   const containerStyle = useMemo(() => ({ width: "100%", height: "100%" }), []);
   const gridStyle = useMemo(() => ({ height: "100%", width: "100%" }), []);
   const [rowData, setRowData] = useState<ResultType[]>([]);
   const [columnDefs, setColumnDefs] = useState<ColDef[]>([]);
-  const [pageNumber, setPageNumber] = useState(1);
-  const [nextPage, setNextPage] = useState("");
-  const [prevPage, setPrevPage] = useState("");
-  const [loading, setLoading] = useState(false);
-
-  const { isFetching: isCountLoading, data: countData = { count: 0 } } =
-    useQuery({
-      queryKey: ["count", project, searchParameters],
-      queryFn: async () => {
-        const search = new URLSearchParams(searchParameters);
-
-        if (httpPathHandler) {
-          return httpPathHandler(
-            `projects/${project}/count/?${search.toString()}`
-          )
-            .then((response) => response.json())
-            .then((data) => {
-              return { count: data.data.count };
-            });
-        }
-      },
-      enabled: !!project && isServerData,
-      cacheTime: 0.5 * 60 * 1000,
-    });
 
   const defaultCellRenderer = (params: CustomCellRendererProps) => {
     if (
@@ -112,9 +77,7 @@ function Table({
         <Button
           size="sm"
           variant="link"
-          onClick={() => {
-            s3PathHandler(params.value);
-          }}
+          onClick={() => s3PathHandler(params.value)}
         >
           {params.value}
         </Button>
@@ -124,35 +87,14 @@ function Table({
     }
   };
 
-  const baseDefaultColDef = (key: string) => {
+  const defaultColDef = (key: string) => {
     return {
       field: key,
       headerName: headerNames?.get(key) || key,
       minWidth: 200,
       headerTooltip: headerTooltips?.get(headerTooltipPrefix + key),
       cellRenderer: defaultCellRenderer,
-    };
-  };
-
-  let defaultColDef: (key: string) => ColDef;
-
-  if (isServerData) {
-    defaultColDef = (key: string) => {
-      return {
-        ...baseDefaultColDef(key),
-        comparator: () => {
-          return 0;
-        },
-      };
-    };
-  } else {
-    defaultColDef = baseDefaultColDef;
-  }
-
-  const handleResultData = (data: ResultData) => {
-    setRowData(formatResultData(data));
-    setNextPage(data.next || "");
-    setPrevPage(data.previous || "");
+    } as ColDef;
   };
 
   const onGridReady = useCallback(() => {
@@ -169,9 +111,7 @@ function Table({
                 <Button
                   size="sm"
                   variant="link"
-                  onClick={() => {
-                    handleRecordModalShow(params.value);
-                  }}
+                  onClick={() => handleRecordModalShow(params.value)}
                 >
                   {params.value}
                 </Button>
@@ -179,15 +119,18 @@ function Table({
             },
           };
         } else {
-          const colDef = {
-            ...defaultColDef(key),
-            cellRenderer: cellRenderers?.get(key) || defaultCellRenderer,
-            autoHeight: cellRenderers?.get(key) ? true : false,
-            wrapText: cellRenderers?.get(key) ? true : false,
-            tooltipValueGetter: tooltipFields?.includes(key)
-              ? (p: ITooltipParams) => p.value.toString()
-              : undefined,
-          };
+          const colDef = defaultColDef(key);
+
+          if (cellRenderers?.get(key)) {
+            colDef.cellRenderer = cellRenderers.get(key);
+            colDef.autoHeight = true;
+            colDef.wrapText = true;
+          }
+
+          if (tooltipFields?.includes(key)) {
+            colDef.tooltipValueGetter = (p: ITooltipParams) =>
+              p.value.toString();
+          }
 
           if (!flexOnly || flexOnly.includes(key)) {
             colDef.flex = 1;
@@ -198,82 +141,278 @@ function Table({
     } else {
       colDefs = [];
     }
-    handleResultData(data);
+    setRowData(formatResultData(data));
     setColumnDefs(colDefs);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const handleSortColumn = (event: SortChangedEvent) => {
-    let field = "";
-    let direction = "";
-    let order = "";
-
-    if (event.columns && event.columns.length > 0) {
-      field = event.columns[event.columns.length - 1].getId();
-      direction = event.columns[event.columns.length - 1].getSort() || "";
-    }
-
-    if (direction === "asc") {
-      order = `${field}`;
-    } else if (direction === "desc") {
-      order = `-${field}`;
-    }
-
-    const search = new URLSearchParams(searchParameters);
-
-    if (order) {
-      search.set("order", order);
-    }
-
-    handlePageChange(search.toString(), 1);
+  const gridOptions = {
+    enableCellTextSelection: true,
+    defaultColDef: {
+      filter: true,
+    },
   };
 
-  const handlePageChange = (params: string, page: number) => {
-    if (httpPathHandler && !loading) {
+  const clearTableFilters = useCallback(() => {
+    gridRef.current!.api.setFilterModel(null);
+  }, []);
+
+  return (
+    <Stack gap={2} style={containerStyle}>
+      <div className="ag-theme-quartz" style={gridStyle}>
+        <AgGridReact
+          ref={gridRef}
+          rowData={rowData}
+          columnDefs={columnDefs}
+          tooltipMouseTrack={true}
+          tooltipHideDelay={5000}
+          gridOptions={gridOptions}
+          onGridReady={onGridReady}
+          suppressMultiSort={true}
+          suppressColumnVirtualisation={true}
+          rowBuffer={30}
+        />
+      </div>
+      <div>
+        <i className="text-secondary">{footer}</i>
+        <div style={{ float: "right" }}>
+          <Container>
+            <Stack direction="horizontal" gap={2}>
+              <Pagination size="sm">
+                <Pagination.Item>
+                  {`${rowData.length >= 1 ? 1 : 0} to ${rowData.length} of ${
+                    rowData.length
+                  }`}
+                </Pagination.Item>
+              </Pagination>
+              <Pagination size="sm">
+                <Button size="sm" variant="dark" onClick={clearTableFilters}>
+                  Clear Table Filters
+                </Button>
+              </Pagination>
+            </Stack>
+          </Container>
+        </div>
+      </div>
+    </Stack>
+  );
+}
+
+function ServerPaginatedTable({
+  data,
+  project,
+  searchParameters,
+  headerNames,
+  headerTooltips,
+  headerTooltipPrefix = "",
+  tooltipFields,
+  flexOnly,
+  footer = "",
+  cellRenderers,
+  handleRecordModalShow,
+  httpPathHandler,
+  s3PathHandler,
+}: {
+  data: ResultData;
+  project: string;
+  searchParameters: string;
+  headerNames?: Map<string, string>;
+  headerTooltips?: Map<string, string>;
+  headerTooltipPrefix?: string;
+  tooltipFields?: string[];
+  flexOnly?: string[];
+  footer?: string;
+  cellRenderers?: Map<string, (params: CustomCellRendererProps) => JSX.Element>;
+  handleRecordModalShow: (climbID: string) => void;
+  httpPathHandler: (path: string) => Promise<Response>;
+  s3PathHandler?: (path: string) => void;
+}) {
+  const containerStyle = useMemo(() => ({ width: "100%", height: "100%" }), []);
+  const gridStyle = useMemo(() => ({ height: "100%", width: "100%" }), []);
+  const [resultData, setResultData] = useState<ResultType[]>([]);
+  const [rowData, setRowData] = useState<ResultType[]>([]);
+  const [columnDefs, setColumnDefs] = useState<ColDef[]>([]);
+  const [userPageNumber, setUserPageNumber] = useState(1);
+  const [serverPageNumber, setServerPageNumber] = useState(1);
+  const [nextPage, setNextPage] = useState("");
+  const [prevPage, setPrevPage] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const { isFetching: isCountLoading, data: countData = { count: 0 } } =
+    useQuery({
+      queryKey: ["count", project, searchParameters],
+      queryFn: async () => {
+        const search = new URLSearchParams(searchParameters).toString();
+        return httpPathHandler(`projects/${project}/count/?${search}`)
+          .then((response) => response.json())
+          .then((data) => {
+            return { count: data.data.count };
+          });
+      },
+      enabled: !!project,
+      cacheTime: 0.5 * 60 * 1000,
+    });
+
+  const defaultCellRenderer = (params: CustomCellRendererProps) => {
+    if (
+      s3PathHandler &&
+      typeof params.value === "string" &&
+      params.value.startsWith("s3://") &&
+      params.value.endsWith(".html")
+    ) {
+      return (
+        <Button
+          size="sm"
+          variant="link"
+          onClick={() => s3PathHandler(params.value)}
+        >
+          {params.value}
+        </Button>
+      );
+    } else {
+      return params.value;
+    }
+  };
+
+  const defaultColDef = (key: string) => {
+    return {
+      field: key,
+      headerName: headerNames?.get(key) || key,
+      minWidth: 200,
+      headerTooltip: headerTooltips?.get(headerTooltipPrefix + key),
+      cellRenderer: defaultCellRenderer,
+      comparator: () => 0,
+    } as ColDef;
+  };
+
+  const userPageMaxRows = 50;
+  const resultsPageMaxRows = 1000;
+  const numUserPages = Math.ceil(countData.count / userPageMaxRows);
+  const numResultsPages = resultsPageMaxRows / userPageMaxRows;
+  const fromCount =
+    (userPageNumber - 1) * userPageMaxRows + (rowData.length >= 1 ? 1 : 0);
+  const toCount = (userPageNumber - 1) * userPageMaxRows + rowData.length;
+  const nextParams = nextPage.split("?", 2)[1];
+  const prevParams = prevPage.split("?", 2)[1];
+  const noPrevPage = !prevPage && userPageNumber <= 1;
+  const noNextPage = !nextPage && userPageNumber >= numUserPages;
+
+  const getRowData = (resultData: ResultType[], resultsPage: number) => {
+    return resultData.slice(
+      (resultsPage - 1) * userPageMaxRows,
+      resultsPage * userPageMaxRows
+    );
+  };
+
+  const getPageNumbers = (userPage: number) => {
+    return {
+      resultsPage: userPage % numResultsPages || numResultsPages,
+      serverPage: Math.ceil((userPage * userPageMaxRows) / 1000),
+    };
+  };
+
+  const handleResultData = (resultData: ResultData, resultsPage: number) => {
+    const formattedResultData = formatResultData(resultData);
+    setResultData(formattedResultData);
+    setRowData(getRowData(formattedResultData, resultsPage));
+    setNextPage(resultData.next || "");
+    setPrevPage(resultData.previous || "");
+  };
+
+  const handleSortColumn = (event: SortChangedEvent) => {
+    const search = new URLSearchParams(searchParameters);
+
+    if (event.columns && event.columns.length > 0) {
+      const field = event.columns[event.columns.length - 1].getId();
+      const direction = event.columns[event.columns.length - 1].getSort() || "";
+
+      if (direction === "asc") {
+        search.set("order", field);
+      } else if (direction === "desc") {
+        search.set("order", `-${field}`);
+      }
+    }
+
+    handleUserPageChange(search.toString(), 1, true);
+  };
+
+  const handleUserPageChange = (
+    params: string,
+    userPage: number,
+    refresh = false
+  ) => {
+    const { resultsPage, serverPage } = getPageNumbers(userPage);
+    setUserPageNumber(userPage);
+    setServerPageNumber(serverPage);
+
+    if (!loading && (refresh || serverPage !== serverPageNumber)) {
       setLoading(true);
       const search = new URLSearchParams(params);
-      search.set("page", page.toString());
+      search.set("page", serverPage.toString());
+      search.delete("cursor");
 
       httpPathHandler(`projects/${project}/?${search.toString()}`)
         .then((response) => response.json())
-        .then((response) => {
-          handleResultData(response);
-          setPageNumber(page);
-        })
-        .finally(() => {
-          setLoading(false);
-        });
+        .then((response) => handleResultData(response, resultsPage))
+        .finally(() => setLoading(false));
+    } else {
+      setRowData(getRowData(resultData, resultsPage));
     }
   };
 
-  let gridOptions: GridOptions;
-  if (isServerData) {
-    gridOptions = {
-      enableCellTextSelection: true,
-      onSortChanged: handleSortColumn,
-    };
-  } else {
-    gridOptions = {
-      enableCellTextSelection: true,
-      defaultColDef: {
-        filter: true,
-      },
-    };
-  }
+  const onGridReady = useCallback(() => {
+    let colDefs: ColDef[];
 
-  const serverDataMaxRows = 1000;
-  const pageCount = Math.ceil(countData.count / serverDataMaxRows);
-  const fromCount =
-    (pageNumber - 1) * serverDataMaxRows + (rowData.length >= 1 ? 1 : 0);
-  const toCount = (pageNumber - 1) * serverDataMaxRows + rowData.length;
-  const countMessage = isCountLoading
-    ? "Loading..."
-    : `${fromCount} to ${toCount} of ${
-        isServerData ? countData.count : rowData.length
-      }`;
-  const pageMessage = isCountLoading
-    ? "Loading..."
-    : `Page ${pageNumber} of ${isServerData ? pageCount : 1}`;
+    if (data.data && data.data.length > 0) {
+      colDefs = Object.keys(data.data[0]).map((key) => {
+        if (key === "climb_id") {
+          return {
+            ...defaultColDef(key),
+            pinned: "left",
+            cellRenderer: (params: CustomCellRendererProps) => {
+              return (
+                <Button
+                  size="sm"
+                  variant="link"
+                  onClick={() => handleRecordModalShow(params.value)}
+                >
+                  {params.value}
+                </Button>
+              );
+            },
+          };
+        } else {
+          const colDef = defaultColDef(key);
+
+          if (cellRenderers?.get(key)) {
+            colDef.cellRenderer = cellRenderers.get(key);
+            colDef.autoHeight = true;
+            colDef.wrapText = true;
+          }
+
+          if (tooltipFields?.includes(key)) {
+            colDef.tooltipValueGetter = (p: ITooltipParams) =>
+              p.value.toString();
+          }
+
+          if (!flexOnly || flexOnly.includes(key)) {
+            colDef.flex = 1;
+          }
+          return colDef;
+        }
+      });
+    } else {
+      colDefs = [];
+    }
+    handleResultData(data, 1);
+    setColumnDefs(colDefs);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const gridOptions = {
+    enableCellTextSelection: true,
+    onSortChanged: handleSortColumn,
+  };
 
   return (
     <Stack gap={2} style={containerStyle}>
@@ -287,6 +426,8 @@ function Table({
           onGridReady={onGridReady}
           suppressMultiSort={true}
           loading={loading}
+          suppressColumnVirtualisation={true}
+          rowBuffer={30}
         />
       </div>
       <div>
@@ -295,35 +436,39 @@ function Table({
           <Container>
             <Stack direction="horizontal" gap={2}>
               <Pagination size="sm">
-                <Pagination.Item>{countMessage}</Pagination.Item>
+                <Pagination.Item>
+                  {isCountLoading
+                    ? "Loading..."
+                    : `${fromCount} to ${toCount} of ${countData.count}`}
+                </Pagination.Item>
               </Pagination>
               <Pagination size="sm">
                 <Pagination.First
-                  disabled={!prevPage}
-                  onClick={() => handlePageChange(urlToParams(prevPage), 1)}
+                  disabled={noPrevPage}
+                  onClick={() => handleUserPageChange(prevParams, 1)}
                 />
                 <Pagination.Prev
-                  disabled={!prevPage}
+                  disabled={noPrevPage}
                   onClick={() =>
-                    handlePageChange(urlToParams(prevPage), pageNumber - 1)
+                    handleUserPageChange(prevParams, userPageNumber - 1)
                   }
                 />
                 <Pagination.Item
                   style={{ minWidth: "100px", textAlign: "center" }}
                 >
-                  {pageMessage}
+                  {isCountLoading
+                    ? "Loading..."
+                    : `Page ${userPageNumber} of ${numUserPages}`}
                 </Pagination.Item>
                 <Pagination.Next
-                  disabled={!nextPage}
+                  disabled={noNextPage}
                   onClick={() =>
-                    handlePageChange(urlToParams(nextPage), pageNumber + 1)
+                    handleUserPageChange(nextParams, userPageNumber + 1)
                   }
                 />
                 <Pagination.Last
-                  disabled={!nextPage}
-                  onClick={() =>
-                    handlePageChange(urlToParams(nextPage), pageCount)
-                  }
+                  disabled={noNextPage}
+                  onClick={() => handleUserPageChange(nextParams, numUserPages)}
                 />
               </Pagination>
             </Stack>
@@ -335,3 +480,4 @@ function Table({
 }
 
 export default Table;
+export { ServerPaginatedTable };

--- a/lib/components/Table.tsx
+++ b/lib/components/Table.tsx
@@ -206,10 +206,10 @@ function TableOptions(props: TableOptionsProps) {
         <DropdownDivider />
         <Dropdown.Header> Page Size </Dropdown.Header>
         {[10, 50, 100, 500, 1000].map((size) => (
-          <Dropdown.Item
-            key={`pageSize${size}`}
-            disabled={!props.isPaginated}
-          >{`${size} rows`}</Dropdown.Item>
+          <Dropdown.Item key={`pageSize${size}`} disabled={!props.isPaginated}>
+            <span>{`${size} rows`}</span>
+            <span style={{ float: "right" }}>{size === 50 ? "✓" : ""}</span>
+          </Dropdown.Item>
         ))}
         <Dropdown.Header>Export Data</Dropdown.Header>
         <Dropdown.Item

--- a/lib/components/Table.tsx
+++ b/lib/components/Table.tsx
@@ -477,7 +477,9 @@ function ServerPaginatedTable(props: ServerPaginatedTableProps) {
         .then((data) => {
           return {
             count: data.data.count,
-            numPages: Math.ceil(data.data.count / userPageSize),
+            numPages: data.data.count
+              ? Math.ceil(data.data.count / userPageSize)
+              : 1,
           };
         });
     },

--- a/lib/components/Table.tsx
+++ b/lib/components/Table.tsx
@@ -26,8 +26,10 @@ import { DataProps } from "../interfaces";
 
 ModuleRegistry.registerModules([ClientSideRowModelModule]);
 
+type FormattedRowData = Record<string, string | number>[];
+
 interface BaseTableProps extends DataProps {
-  rowData: Record<string, string | number>[];
+  rowData: FormattedRowData;
   columnDefs: ColDef[];
   gridOptions?: GridOptions;
   onGridReady: () => void;
@@ -369,7 +371,7 @@ function BaseTable(props: BaseTableProps) {
 }
 
 function Table(props: TableProps) {
-  const [rowData, setRowData] = useState<Record<string, string | number>[]>([]);
+  const [rowData, setRowData] = useState<FormattedRowData>([]);
   const [columnDefs, setColumnDefs] = useState<ColDef[]>([]);
 
   const defaultColDef = (key: string) => {
@@ -415,10 +417,8 @@ function Table(props: TableProps) {
 }
 
 function ServerPaginatedTable(props: ServerPaginatedTableProps) {
-  const [resultData, setResultData] = useState<
-    Record<string, string | number>[]
-  >([]);
-  const [rowData, setRowData] = useState<Record<string, string | number>[]>([]);
+  const [resultData, setResultData] = useState<FormattedRowData>([]);
+  const [rowData, setRowData] = useState<FormattedRowData>([]);
   const [columnDefs, setColumnDefs] = useState<ColDef[]>([]);
   const [userPageNumber, setUserPageNumber] = useState(1);
   const [serverPageNumber, setServerPageNumber] = useState(1);
@@ -457,10 +457,7 @@ function ServerPaginatedTable(props: ServerPaginatedTableProps) {
   const prevPage = !!(prevParams || userPageNumber > 1);
   const nextPage = !!(nextParams || userPageNumber < countData.numPages);
 
-  const getRowData = (
-    resultData: Record<string, string | number>[],
-    resultsPage: number
-  ) => {
+  const getRowData = (resultData: FormattedRowData, resultsPage: number) => {
     return resultData.slice(
       (resultsPage - 1) * userPageSize,
       resultsPage * userPageSize
@@ -476,10 +473,7 @@ function ServerPaginatedTable(props: ServerPaginatedTableProps) {
     };
   };
 
-  const handleRowData = (
-    rowData: Record<string, string | number>[],
-    userPage: number
-  ) => {
+  const handleRowData = (rowData: FormattedRowData, userPage: number) => {
     setRowData(rowData);
     setUserRowCounts({
       fromCount: (userPage - 1) * userPageSize + (rowData.length >= 1 ? 1 : 0),

--- a/lib/components/Table.tsx
+++ b/lib/components/Table.tsx
@@ -217,7 +217,7 @@ function TableOptions(props: TableOptionsProps) {
   );
 
   const clearTableFilters = useCallback(
-    () => props.gridRef.current!.api.setFilterModel(null),
+    () => props.gridRef.current?.api.setFilterModel(null),
     [props.gridRef]
   );
 
@@ -332,6 +332,13 @@ function BaseTable(props: BaseTableProps) {
   const gridRef = useRef<AgGridReact<Record<string, string | number>>>(null);
   const containerStyle = useMemo(() => ({ width: "100%", height: "100%" }), []);
   const gridStyle = useMemo(() => ({ height: "100%", width: "100%" }), []);
+  const [displayedRowCount, setDisplayedRowCount] = useState(0);
+
+  const updateDisplayedRowCount = useCallback(() => {
+    if (!props.isPaginated) {
+      setDisplayedRowCount(gridRef.current?.api.getDisplayedRowCount() || 0);
+    }
+  }, [gridRef, props.isPaginated]);
 
   return (
     <Stack gap={2} style={containerStyle}>
@@ -350,6 +357,8 @@ function BaseTable(props: BaseTableProps) {
             },
           }}
           onGridReady={props.onGridReady}
+          onRowDataUpdated={updateDisplayedRowCount}
+          onFilterChanged={updateDisplayedRowCount}
           suppressMultiSort={true}
           suppressColumnVirtualisation={true}
           suppressCellFocus={true}
@@ -366,7 +375,11 @@ function BaseTable(props: BaseTableProps) {
                 <Pagination.Item>
                   {props.isCountLoading
                     ? "Loading..."
-                    : `${props.rowDisplayParams.from} to ${props.rowDisplayParams.to} of ${props.rowDisplayParams.of}`}
+                    : `${props.rowDisplayParams.from} to ${
+                        props.isPaginated
+                          ? props.rowDisplayParams.to
+                          : displayedRowCount
+                      } of ${props.rowDisplayParams.of}`}
                 </Pagination.Item>
               </Pagination>
               <TablePagination {...props} />

--- a/lib/components/Table.tsx
+++ b/lib/components/Table.tsx
@@ -401,11 +401,13 @@ function Table(props: TableProps) {
   const [columnDefs, setColumnDefs] = useState<ColDef[]>([]);
 
   const defaultColDef = (key: string) => {
+    const prefix = props.headerTooltipPrefix || "";
+
     return {
       field: key,
       headerName: props.headerNames?.get(key) || key,
       minWidth: 200,
-      headerTooltip: props.headerTooltips?.get(props.headerTooltipPrefix + key),
+      headerTooltip: props.headerTooltips?.get(prefix + key),
     } as ColDef;
   };
 
@@ -565,11 +567,13 @@ function ServerPaginatedTable(props: ServerPaginatedTableProps) {
   };
 
   const defaultColDef = (key: string) => {
+    const prefix = props.headerTooltipPrefix || "";
+
     return {
       field: key,
       headerName: props.headerNames?.get(key) || key,
       minWidth: 200,
-      headerTooltip: props.headerTooltips?.get(props.headerTooltipPrefix + key),
+      headerTooltip: props.headerTooltips?.get(prefix + key),
       comparator: () => 0,
     } as ColDef;
   };

--- a/lib/components/Table.tsx
+++ b/lib/components/Table.tsx
@@ -234,8 +234,8 @@ function ServerPaginatedTable({
   const [columnDefs, setColumnDefs] = useState<ColDef[]>([]);
   const [userPageNumber, setUserPageNumber] = useState(1);
   const [serverPageNumber, setServerPageNumber] = useState(1);
-  const [nextPage, setNextPage] = useState("");
-  const [prevPage, setPrevPage] = useState("");
+  const [prevParams, setPrevParams] = useState("");
+  const [nextParams, setNextParams] = useState("");
   const [loading, setLoading] = useState(false);
 
   const { isFetching: isCountLoading, data: countData = { count: 0 } } =
@@ -292,10 +292,8 @@ function ServerPaginatedTable({
   const fromCount =
     (userPageNumber - 1) * userPageMaxRows + (rowData.length >= 1 ? 1 : 0);
   const toCount = (userPageNumber - 1) * userPageMaxRows + rowData.length;
-  const nextParams = nextPage.split("?", 2)[1];
-  const prevParams = prevPage.split("?", 2)[1];
-  const noPrevPage = !prevPage && userPageNumber <= 1;
-  const noNextPage = !nextPage && userPageNumber >= numUserPages;
+  const prevPage = prevParams || userPageNumber > 1;
+  const nextPage = nextParams || userPageNumber < numUserPages;
 
   const getRowData = (resultData: ResultType[], resultsPage: number) => {
     return resultData.slice(
@@ -307,7 +305,7 @@ function ServerPaginatedTable({
   const getPageNumbers = (userPage: number) => {
     return {
       resultsPage: userPage % numResultsPages || numResultsPages,
-      serverPage: Math.ceil((userPage * userPageMaxRows) / 1000),
+      serverPage: Math.ceil((userPage * userPageMaxRows) / resultsPageMaxRows),
     };
   };
 
@@ -315,8 +313,8 @@ function ServerPaginatedTable({
     const formattedResultData = formatResultData(resultData);
     setResultData(formattedResultData);
     setRowData(getRowData(formattedResultData, resultsPage));
-    setNextPage(resultData.next || "");
-    setPrevPage(resultData.previous || "");
+    setPrevParams(resultData.previous?.split("?", 2)[1] || "");
+    setNextParams(resultData.next?.split("?", 2)[1] || "");
   };
 
   const handleSortColumn = (event: SortChangedEvent) => {
@@ -444,11 +442,11 @@ function ServerPaginatedTable({
               </Pagination>
               <Pagination size="sm">
                 <Pagination.First
-                  disabled={noPrevPage}
+                  disabled={!prevPage}
                   onClick={() => handleUserPageChange(prevParams, 1)}
                 />
                 <Pagination.Prev
-                  disabled={noPrevPage}
+                  disabled={!prevPage}
                   onClick={() =>
                     handleUserPageChange(prevParams, userPageNumber - 1)
                   }
@@ -461,13 +459,13 @@ function ServerPaginatedTable({
                     : `Page ${userPageNumber} of ${numUserPages}`}
                 </Pagination.Item>
                 <Pagination.Next
-                  disabled={noNextPage}
+                  disabled={!nextPage}
                   onClick={() =>
                     handleUserPageChange(nextParams, userPageNumber + 1)
                   }
                 />
                 <Pagination.Last
-                  disabled={noNextPage}
+                  disabled={!nextPage}
                   onClick={() => handleUserPageChange(nextParams, numUserPages)}
                 />
               </Pagination>

--- a/lib/components/Table.tsx
+++ b/lib/components/Table.tsx
@@ -5,6 +5,7 @@ import "@ag-grid-community/styles/ag-theme-quartz.min.css"; // Optional Theme ap
 import { ClientSideRowModelModule } from "@ag-grid-community/client-side-row-model";
 import {
   ColDef,
+  GridOptions,
   SortChangedEvent,
   ModuleRegistry,
   ITooltipParams,
@@ -13,11 +14,52 @@ import { useQuery } from "@tanstack/react-query";
 import Button from "react-bootstrap/Button";
 import Container from "react-bootstrap/Container";
 import Pagination from "react-bootstrap/Pagination";
+import Toast from "react-bootstrap/Toast";
+import ToastContainer from "react-bootstrap/ToastContainer";
 import Stack from "react-bootstrap/Stack";
-import { ResultData, ResultType } from "../types";
+import { mkConfig, generateCsv, asString } from "export-to-csv";
+import { ResultData } from "../types";
 import { DataProps } from "../interfaces";
 
 ModuleRegistry.registerModules([ClientSideRowModelModule]);
+
+interface BaseTableProps extends DataProps {
+  rowData: Record<string, string | number>[];
+  columnDefs: ColDef[];
+  gridOptions?: GridOptions;
+  onGridReady: () => void;
+  rowCountMessage: string;
+  footer?: string;
+  loading?: boolean;
+  isFilterable: boolean;
+  isPaginated: boolean;
+  paginationParams: {
+    pageCountMessage: string;
+    pageNumber: number;
+    numPages: number;
+    prevPage: boolean;
+    nextPage: boolean;
+    prevParams: string;
+    nextParams: string;
+    handleUserPageChange: (params: string, userPage: number) => void;
+  };
+}
+
+interface TableProps extends DataProps {
+  data: ResultData;
+  headerNames?: Map<string, string>;
+  headerTooltips?: Map<string, string>;
+  headerTooltipPrefix?: string;
+  tooltipFields?: string[];
+  flexOnly?: string[];
+  footer?: string;
+  cellRenderers?: Map<string, (params: CustomCellRendererProps) => JSX.Element>;
+  handleRecordModalShow?: (climbID: string) => void;
+}
+
+interface ServerPaginatedTableProps extends TableProps {
+  searchParameters: string;
+}
 
 function formatResultData(resultData: ResultData) {
   // For table display, we allow string and number values
@@ -38,27 +80,186 @@ function formatResultData(resultData: ResultData) {
   );
 }
 
-interface TableProps extends DataProps {
-  data: ResultData;
-  headerNames?: Map<string, string>;
-  headerTooltips?: Map<string, string>;
-  headerTooltipPrefix?: string;
-  tooltipFields?: string[];
-  flexOnly?: string[];
-  footer?: string;
-  cellRenderers?: Map<string, (params: CustomCellRendererProps) => JSX.Element>;
-  handleRecordModalShow?: (climbID: string) => void;
-}
+// function formatResultData(resultData: ResultData) {
+//   // For CSV export, we allow string, number and boolean values
+//   // All other types are converted to strings
+//   return (
+//     resultData.data?.map((row) =>
+//       Object.fromEntries(
+//         Object.entries(row).map(([key, value]) => [
+//           key,
+//           typeof value === "string" ||
+//           typeof value === "number" ||
+//           typeof value === "boolean"
+//             ? value
+//             : value === null
+//             ? ""
+//             : JSON.stringify(value),
+//         ])
+//       )
+//     ) || []
+//   );
+// }
 
-interface ServerPaginatedTableProps extends TableProps {
-  searchParameters: string;
+function BaseTable(props: BaseTableProps) {
+  const gridRef = useRef<AgGridReact<Record<string, string | number>>>(null);
+  const containerStyle = useMemo(() => ({ width: "100%", height: "100%" }), []);
+  const gridStyle = useMemo(() => ({ height: "100%", width: "100%" }), []);
+  const [toastVisible, setToastVisible] = useState(false);
+  const [toastMessage, setToastMessage] = useState("");
+  const csvConfig = mkConfig({
+    filename: props.project,
+    useKeysAsHeaders: true,
+  });
+
+  const handleExportToCSV = () => {
+    // const fileName = `${props.project}${
+    //   props.pageNumber > 1 ? "_" + props.pageNumber.toString() : ""
+    // }`;
+
+    const csvData = asString(generateCsv(csvConfig)(props.rowData));
+
+    if (props.fileWriter) {
+      showNotification("Starting export: " + props.project + ".csv");
+      props.fileWriter(props.project + ".csv", csvData);
+    }
+  };
+
+  const showNotification = (message: string) => {
+    setToastMessage(message);
+    setToastVisible(true);
+  };
+
+  const clearTableFilters = useCallback(() => {
+    gridRef.current!.api.setFilterModel(null);
+  }, []);
+
+  return (
+    <Stack gap={2} style={containerStyle}>
+      <div className="ag-theme-quartz" style={gridStyle}>
+        <Container
+          fluid
+          className="p-0 position-relative"
+          style={containerStyle}
+        >
+          <ToastContainer
+            className="p-3"
+            position="bottom-end"
+            style={{ zIndex: 1 }}
+          >
+            <Toast
+              onClose={() => setToastVisible(false)}
+              show={toastVisible}
+              delay={3000}
+              autohide
+            >
+              <Toast.Header>
+                <strong className="me-auto">Notification</strong>
+              </Toast.Header>
+              <Toast.Body>{toastMessage}</Toast.Body>
+            </Toast>
+          </ToastContainer>
+          <AgGridReact
+            ref={gridRef}
+            rowData={props.rowData}
+            columnDefs={props.columnDefs}
+            tooltipMouseTrack={true}
+            tooltipHideDelay={5000}
+            gridOptions={{
+              ...props.gridOptions,
+              enableCellTextSelection: true,
+              defaultColDef: {
+                filter: props.isFilterable,
+              },
+            }}
+            onGridReady={props.onGridReady}
+            suppressMultiSort={true}
+            suppressColumnVirtualisation={true}
+            rowBuffer={30}
+            loading={props.loading}
+          />
+        </Container>
+      </div>
+      <div>
+        <i className="text-secondary">{props.footer || ""}</i>
+        <div style={{ float: "right" }}>
+          <Container>
+            <Stack direction="horizontal" gap={2}>
+              <Pagination size="sm">
+                <Pagination.Item>{props.rowCountMessage}</Pagination.Item>
+              </Pagination>
+              {props.isPaginated && (
+                <Pagination size="sm">
+                  <Pagination.First
+                    disabled={!props.paginationParams.prevPage}
+                    onClick={() =>
+                      props.paginationParams.handleUserPageChange(
+                        props.paginationParams.prevParams,
+                        1
+                      )
+                    }
+                  />
+                  <Pagination.Prev
+                    disabled={!props.paginationParams.prevPage}
+                    onClick={() =>
+                      props.paginationParams.handleUserPageChange(
+                        props.paginationParams.prevParams,
+                        props.paginationParams.pageNumber - 1
+                      )
+                    }
+                  />
+                  <Pagination.Item
+                    style={{ minWidth: "150px", textAlign: "center" }}
+                  >
+                    {props.paginationParams.pageCountMessage}
+                  </Pagination.Item>
+                  <Pagination.Next
+                    disabled={!props.paginationParams.nextPage}
+                    onClick={() =>
+                      props.paginationParams.handleUserPageChange(
+                        props.paginationParams.nextParams,
+                        props.paginationParams.pageNumber + 1
+                      )
+                    }
+                  />
+                  <Pagination.Last
+                    disabled={!props.paginationParams.nextPage}
+                    onClick={() =>
+                      props.paginationParams.handleUserPageChange(
+                        props.paginationParams.nextParams,
+                        props.paginationParams.numPages
+                      )
+                    }
+                  />
+                </Pagination>
+              )}
+              {props.isFilterable && (
+                <Pagination size="sm">
+                  <Button size="sm" variant="dark" onClick={clearTableFilters}>
+                    Clear Filters
+                  </Button>
+                </Pagination>
+              )}
+              <Pagination size="sm">
+                <Button
+                  size="sm"
+                  disabled={!props.fileWriter}
+                  variant="dark"
+                  onClick={handleExportToCSV}
+                >
+                  Export to CSV
+                </Button>
+              </Pagination>
+            </Stack>
+          </Container>
+        </div>
+      </div>
+    </Stack>
+  );
 }
 
 function Table(props: TableProps) {
-  const gridRef = useRef<AgGridReact<ResultType>>(null);
-  const containerStyle = useMemo(() => ({ width: "100%", height: "100%" }), []);
-  const gridStyle = useMemo(() => ({ height: "100%", width: "100%" }), []);
-  const [rowData, setRowData] = useState<ResultType[]>([]);
+  const [rowData, setRowData] = useState<Record<string, string | number>[]>([]);
   const [columnDefs, setColumnDefs] = useState<ColDef[]>([]);
 
   const defaultCellRenderer = (params: CustomCellRendererProps) => {
@@ -147,63 +348,37 @@ function Table(props: TableProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const gridOptions = {
-    enableCellTextSelection: true,
-    defaultColDef: {
-      filter: true,
-    },
-  };
-
-  const clearTableFilters = useCallback(() => {
-    gridRef.current!.api.setFilterModel(null);
-  }, []);
-
   return (
-    <Stack gap={2} style={containerStyle}>
-      <div className="ag-theme-quartz" style={gridStyle}>
-        <AgGridReact
-          ref={gridRef}
-          rowData={rowData}
-          columnDefs={columnDefs}
-          tooltipMouseTrack={true}
-          tooltipHideDelay={5000}
-          gridOptions={gridOptions}
-          onGridReady={onGridReady}
-          suppressMultiSort={true}
-          suppressColumnVirtualisation={true}
-          rowBuffer={30}
-        />
-      </div>
-      <div>
-        <i className="text-secondary">{props.footer}</i>
-        <div style={{ float: "right" }}>
-          <Container>
-            <Stack direction="horizontal" gap={2}>
-              <Pagination size="sm">
-                <Pagination.Item>
-                  {`${rowData.length >= 1 ? 1 : 0} to ${rowData.length} of ${
-                    rowData.length
-                  }`}
-                </Pagination.Item>
-              </Pagination>
-              <Pagination size="sm">
-                <Button size="sm" variant="dark" onClick={clearTableFilters}>
-                  Clear Table Filters
-                </Button>
-              </Pagination>
-            </Stack>
-          </Container>
-        </div>
-      </div>
-    </Stack>
+    <BaseTable
+      {...props}
+      rowData={rowData}
+      columnDefs={columnDefs}
+      onGridReady={onGridReady}
+      rowCountMessage={`${rowData.length >= 1 ? 1 : 0} to ${
+        rowData.length
+      } of ${rowData.length}`}
+      footer={props.footer}
+      isFilterable
+      isPaginated={false}
+      paginationParams={{
+        pageNumber: 1,
+        numPages: 1,
+        pageCountMessage: "",
+        prevPage: false,
+        nextPage: false,
+        prevParams: "",
+        nextParams: "",
+        handleUserPageChange: () => {},
+      }}
+    />
   );
 }
 
 function ServerPaginatedTable(props: ServerPaginatedTableProps) {
-  const containerStyle = useMemo(() => ({ width: "100%", height: "100%" }), []);
-  const gridStyle = useMemo(() => ({ height: "100%", width: "100%" }), []);
-  const [resultData, setResultData] = useState<ResultType[]>([]);
-  const [rowData, setRowData] = useState<ResultType[]>([]);
+  const [resultData, setResultData] = useState<
+    Record<string, string | number>[]
+  >([]);
+  const [rowData, setRowData] = useState<Record<string, string | number>[]>([]);
   const [columnDefs, setColumnDefs] = useState<ColDef[]>([]);
   const [userPageNumber, setUserPageNumber] = useState(1);
   const [serverPageNumber, setServerPageNumber] = useState(1);
@@ -268,10 +443,13 @@ function ServerPaginatedTable(props: ServerPaginatedTableProps) {
   const fromCount =
     (userPageNumber - 1) * userPageMaxRows + (rowData.length >= 1 ? 1 : 0);
   const toCount = (userPageNumber - 1) * userPageMaxRows + rowData.length;
-  const prevPage = prevParams || userPageNumber > 1;
-  const nextPage = nextParams || userPageNumber < numUserPages;
+  const prevPage = !!(prevParams || userPageNumber > 1);
+  const nextPage = !!(nextParams || userPageNumber < numUserPages);
 
-  const getRowData = (resultData: ResultType[], resultsPage: number) => {
+  const getRowData = (
+    resultData: Record<string, string | number>[],
+    resultsPage: number
+  ) => {
     return resultData.slice(
       (resultsPage - 1) * userPageMaxRows,
       resultsPage * userPageMaxRows
@@ -387,73 +565,33 @@ function ServerPaginatedTable(props: ServerPaginatedTableProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const gridOptions = {
-    enableCellTextSelection: true,
-    onSortChanged: handleSortColumn,
-  };
-
   return (
-    <Stack gap={2} style={containerStyle}>
-      <div className="ag-theme-quartz" style={gridStyle}>
-        <AgGridReact
-          rowData={rowData}
-          columnDefs={columnDefs}
-          tooltipMouseTrack={true}
-          tooltipHideDelay={5000}
-          gridOptions={gridOptions}
-          onGridReady={onGridReady}
-          suppressMultiSort={true}
-          loading={loading}
-          suppressColumnVirtualisation={true}
-          rowBuffer={30}
-        />
-      </div>
-      <div>
-        <i className="text-secondary">{props.footer}</i>
-        <div style={{ float: "right" }}>
-          <Container>
-            <Stack direction="horizontal" gap={2}>
-              <Pagination size="sm">
-                <Pagination.Item>
-                  {isCountLoading
-                    ? "Loading..."
-                    : `${fromCount} to ${toCount} of ${countData.count}`}
-                </Pagination.Item>
-              </Pagination>
-              <Pagination size="sm">
-                <Pagination.First
-                  disabled={!prevPage}
-                  onClick={() => handleUserPageChange(prevParams, 1)}
-                />
-                <Pagination.Prev
-                  disabled={!prevPage}
-                  onClick={() =>
-                    handleUserPageChange(prevParams, userPageNumber - 1)
-                  }
-                />
-                <Pagination.Item
-                  style={{ minWidth: "100px", textAlign: "center" }}
-                >
-                  {isCountLoading
-                    ? "Loading..."
-                    : `Page ${userPageNumber} of ${numUserPages}`}
-                </Pagination.Item>
-                <Pagination.Next
-                  disabled={!nextPage}
-                  onClick={() =>
-                    handleUserPageChange(nextParams, userPageNumber + 1)
-                  }
-                />
-                <Pagination.Last
-                  disabled={!nextPage}
-                  onClick={() => handleUserPageChange(nextParams, numUserPages)}
-                />
-              </Pagination>
-            </Stack>
-          </Container>
-        </div>
-      </div>
-    </Stack>
+    <BaseTable
+      {...props}
+      rowData={rowData}
+      columnDefs={columnDefs}
+      gridOptions={{
+        onSortChanged: handleSortColumn,
+      }}
+      onGridReady={onGridReady}
+      rowCountMessage={`${fromCount} to ${toCount} of ${countData.count}`}
+      footer={props.footer}
+      loading={loading}
+      isFilterable={false}
+      isPaginated
+      paginationParams={{
+        pageCountMessage: isCountLoading
+          ? "Loading..."
+          : `Page ${userPageNumber} of ${numUserPages}`,
+        pageNumber: userPageNumber,
+        numPages: numUserPages,
+        prevPage,
+        nextPage,
+        prevParams,
+        nextParams,
+        handleUserPageChange,
+      }}
+    />
   );
 }
 

--- a/lib/components/TransformsPanel.tsx
+++ b/lib/components/TransformsPanel.tsx
@@ -27,7 +27,7 @@ function TransformsPanel(props: TransformsPanelProps) {
   };
 
   return (
-    <Card>
+    <Card className="h-50">
       <Card.Header>
         <NavDropdown title={props.transform}>
           {["Summarise", "Include", "Exclude"].map((action) => (
@@ -40,7 +40,7 @@ function TransformsPanel(props: TransformsPanelProps) {
           ))}
         </NavDropdown>
       </Card.Header>
-      <Container fluid className="onyx-parameters-panel-body p-2">
+      <Container fluid className="overflow-y-scroll p-2 h-100">
         <MultiDropdown
           options={
             props.transform === "Summarise"

--- a/lib/interfaces.ts
+++ b/lib/interfaces.ts
@@ -1,4 +1,4 @@
-import { ProjectField } from "./types";
+import { ProjectField, ExportStatus } from "./types";
 
 interface OnyxProps {
   httpPathHandler: (path: string) => Promise<Response>;
@@ -21,4 +21,11 @@ interface StatsProps extends OnyxProps {
   darkMode: boolean;
 }
 
-export type { OnyxProps, DataProps, StatsProps };
+interface ExportHandlerProps {
+  fileName: string;
+  statusToken: { status: ExportStatus };
+  setExportProgress: (exportProgress: number) => void;
+  setExportStatus: (exportStatus: ExportStatus) => void;
+}
+
+export type { OnyxProps, DataProps, StatsProps, ExportHandlerProps };

--- a/lib/pages/Data.tsx
+++ b/lib/pages/Data.tsx
@@ -125,43 +125,45 @@ function Data(props: DataProps) {
   };
 
   return (
-    <Container fluid className="g-2">
+    <Container fluid className="g-2 h-100">
       <RecordModal
         {...props}
         recordID={recordModalID}
         show={recordModalShow}
         onHide={handleRecordModalHide}
       />
-      <div className="parent">
-        <div className="left-col">
-          <Container fluid className="g-2">
-            <Stack gap={2}>
+      <div className="parent h-100">
+        <div className="left-col h-100">
+          <Container fluid className="g-2 h-100">
+            <Stack gap={2} className="h-100">
               <SearchBar
                 {...props}
                 searchInput={searchInput}
                 setSearchInput={setSearchInput}
                 handleSearch={handleSearch}
               />
-              <FilterPanel
-                {...props}
-                filterList={filterList}
-                setFilterList={setFilterList}
-                filterFieldOptions={filterFieldOptions}
-              />
-              <TransformsPanel
-                {...props}
-                transform={transform}
-                setTransform={setTransform}
-                transformList={transformList}
-                setTransformList={setTransformList}
-                filterFieldOptions={filterFieldOptions}
-                listFieldOptions={listFieldOptions}
-              />
+              <Stack gap={2} className="h-100 overflow-y-hidden">
+                <FilterPanel
+                  {...props}
+                  filterList={filterList}
+                  setFilterList={setFilterList}
+                  filterFieldOptions={filterFieldOptions}
+                />
+                <TransformsPanel
+                  {...props}
+                  transform={transform}
+                  setTransform={setTransform}
+                  transformList={transformList}
+                  setTransformList={setTransformList}
+                  filterFieldOptions={filterFieldOptions}
+                  listFieldOptions={listFieldOptions}
+                />
+              </Stack>
             </Stack>
           </Container>
         </div>
-        <div className="right-col">
-          <Container fluid className="g-2">
+        <div className="right-col h-100">
+          <Container fluid className="g-2 h-100">
             {props.project && (
               <ResultsPanel
                 {...props}

--- a/lib/pages/Data.tsx
+++ b/lib/pages/Data.tsx
@@ -21,7 +21,6 @@ function Data(props: DataProps) {
   const [transform, setTransform] = useState("Summarise");
   const [transformList, setTransformList] = useState(new Array<string>());
   const [searchParameters, setSearchParameters] = useState("");
-  const [pageNumber, setPageNumber] = useState(1);
   const [recordModalShow, setRecordModalShow] = React.useState(false);
   const [recordModalID, setRecordModalID] = React.useState("");
   const filterFieldOptions = Array.from(props.projectFields.entries())
@@ -38,7 +37,6 @@ function Data(props: DataProps) {
     setTransform("Summarise");
     setTransformList([]);
     setSearchParameters("");
-    setPageNumber(1);
     setRecordModalShow(false);
     setRecordModalID("");
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -95,7 +93,6 @@ function Data(props: DataProps) {
       // This will trigger a new fetch
       setSearchParameters(search);
     }
-    setPageNumber(1);
   };
 
   // https://react.dev/reference/react/useCallback#skipping-re-rendering-of-components
@@ -154,8 +151,6 @@ function Data(props: DataProps) {
           resultData={resultData}
           searchParameters={searchParameters}
           setSearchParameters={setSearchParameters}
-          pageNumber={pageNumber}
-          setPageNumber={setPageNumber}
           handleRecordModalShow={handleRecordModalShow}
         />
       </Stack>

--- a/lib/pages/Data.tsx
+++ b/lib/pages/Data.tsx
@@ -1,4 +1,9 @@
-import React, { useState, useLayoutEffect, useCallback } from "react";
+import React, {
+  useState,
+  useLayoutEffect,
+  useCallback,
+  // useEffect,
+} from "react";
 import Container from "react-bootstrap/Container";
 import Row from "react-bootstrap/Row";
 import Col from "react-bootstrap/Col";
@@ -12,6 +17,19 @@ import RecordModal from "../components/RecordModal";
 import { FilterField } from "../types";
 import { DataProps } from "../interfaces";
 import generateKey from "../utils/generateKey";
+
+// const useDebouncedValue = (inputValue: string, delay: number) => {
+//   const [debouncedValue, setDebouncedValue] = useState(inputValue);
+//   useEffect(() => {
+//     const handler = setTimeout(() => {
+//       setDebouncedValue(inputValue);
+//     }, delay);
+//     return () => {
+//       clearTimeout(handler);
+//     };
+//   }, [inputValue, delay]);
+//   return debouncedValue;
+// };
 
 function Data(props: DataProps) {
   const defaultFilterList = () =>
@@ -40,6 +58,29 @@ function Data(props: DataProps) {
     setRecordModalShow(false);
     setRecordModalID("");
   }, [props.project]);
+
+  // const sParams = new URLSearchParams(
+  //   filterList
+  //     .filter((filter) => filter.field)
+  //     .map((filter) => {
+  //       if (filter.lookup) {
+  //         return [filter.field + "__" + filter.lookup, filter.value];
+  //       } else {
+  //         return [filter.field, filter.value];
+  //       }
+  //     })
+  //     .concat(
+  //       transformList
+  //         .filter((field) => field)
+  //         .map((field) => [transform.toLowerCase(), field])
+  //     )
+  //     .concat(
+  //       [searchInput]
+  //         .filter((search) => search)
+  //         .map((search) => ["search", search])
+  //     )
+  // ).toString();
+  // const searchParameters = useDebouncedValue(sParams, 1000);
 
   // Fetch data, depending on project and search parameters
   const {
@@ -149,7 +190,6 @@ function Data(props: DataProps) {
           resultError={resultError instanceof Error ? resultError : null}
           resultData={resultData}
           searchParameters={searchParameters}
-          setSearchParameters={setSearchParameters}
           handleRecordModalShow={handleRecordModalShow}
         />
       </Stack>

--- a/lib/pages/Data.tsx
+++ b/lib/pages/Data.tsx
@@ -39,7 +39,6 @@ function Data(props: DataProps) {
     setSearchParameters("");
     setRecordModalShow(false);
     setRecordModalID("");
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.project]);
 
   // Fetch data, depending on project and search parameters

--- a/lib/pages/Data.tsx
+++ b/lib/pages/Data.tsx
@@ -1,12 +1,11 @@
 import React, {
   useState,
-  useLayoutEffect,
+  useMemo,
   useCallback,
-  // useEffect,
+  useLayoutEffect,
+  useEffect,
 } from "react";
 import Container from "react-bootstrap/Container";
-import Row from "react-bootstrap/Row";
-import Col from "react-bootstrap/Col";
 import Stack from "react-bootstrap/Stack";
 import { useQuery } from "@tanstack/react-query";
 import SearchBar from "../components/SearchBar";
@@ -16,26 +15,23 @@ import ResultsPanel from "../components/ResultsPanel";
 import RecordModal from "../components/RecordModal";
 import { FilterField } from "../types";
 import { DataProps } from "../interfaces";
-import generateKey from "../utils/generateKey";
 
-// const useDebouncedValue = (inputValue: string, delay: number) => {
-//   const [debouncedValue, setDebouncedValue] = useState(inputValue);
-//   useEffect(() => {
-//     const handler = setTimeout(() => {
-//       setDebouncedValue(inputValue);
-//     }, delay);
-//     return () => {
-//       clearTimeout(handler);
-//     };
-//   }, [inputValue, delay]);
-//   return debouncedValue;
-// };
+const useDebouncedValue = (inputValue: string, delay: number) => {
+  const [debouncedValue, setDebouncedValue] = useState(inputValue);
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedValue(inputValue);
+    }, delay);
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [inputValue, delay]);
+  return debouncedValue;
+};
 
 function Data(props: DataProps) {
-  const defaultFilterList = () =>
-    [{ key: generateKey(), field: "", lookup: "", value: "" }] as FilterField[];
   const [searchInput, setSearchInput] = useState("");
-  const [filterList, setFilterList] = useState(defaultFilterList());
+  const [filterList, setFilterList] = useState([] as FilterField[]);
   const [transform, setTransform] = useState("Summarise");
   const [transformList, setTransformList] = useState(new Array<string>());
   const [searchParameters, setSearchParameters] = useState("");
@@ -51,36 +47,13 @@ function Data(props: DataProps) {
   // Clear parameters when project changes
   useLayoutEffect(() => {
     setSearchInput("");
-    setFilterList(defaultFilterList());
+    setFilterList([]);
     setTransform("Summarise");
     setTransformList([]);
     setSearchParameters("");
     setRecordModalShow(false);
     setRecordModalID("");
   }, [props.project]);
-
-  // const sParams = new URLSearchParams(
-  //   filterList
-  //     .filter((filter) => filter.field)
-  //     .map((filter) => {
-  //       if (filter.lookup) {
-  //         return [filter.field + "__" + filter.lookup, filter.value];
-  //       } else {
-  //         return [filter.field, filter.value];
-  //       }
-  //     })
-  //     .concat(
-  //       transformList
-  //         .filter((field) => field)
-  //         .map((field) => [transform.toLowerCase(), field])
-  //     )
-  //     .concat(
-  //       [searchInput]
-  //         .filter((search) => search)
-  //         .map((search) => ["search", search])
-  //     )
-  // ).toString();
-  // const searchParameters = useDebouncedValue(sParams, 1000);
 
   // Fetch data, depending on project and search parameters
   const {
@@ -99,40 +72,43 @@ function Data(props: DataProps) {
     cacheTime: 0.5 * 60 * 1000,
   });
 
-  const handleSearch = () => {
-    const search = new URLSearchParams(
-      filterList
-        .filter((filter) => filter.field)
-        .map((filter) => {
-          if (filter.lookup) {
-            return [filter.field + "__" + filter.lookup, filter.value];
-          } else {
-            return [filter.field, filter.value];
-          }
-        })
-        .concat(
-          transformList
-            .filter((field) => field)
-            .map((field) => [transform.toLowerCase(), field])
-        )
-        .concat(
-          [searchInput]
-            .filter((search) => search)
-            .map((search) => ["search", search])
-        )
-    ).toString();
+  const searchParams = useMemo(
+    () =>
+      new URLSearchParams(
+        filterList
+          .filter((filter) => filter.field)
+          .map((filter) => {
+            if (filter.lookup) {
+              return [filter.field + "__" + filter.lookup, filter.value];
+            } else {
+              return [filter.field, filter.value];
+            }
+          })
+          .concat(
+            transformList
+              .filter((field) => field)
+              .map((field) => [transform.toLowerCase(), field])
+          )
+          .concat(
+            [searchInput]
+              .filter((search) => search)
+              .map((search) => ["search", search])
+          )
+      ).toString(),
+    [filterList, transform, transformList, searchInput]
+  );
 
-    if (searchParameters === search) {
-      if (!resultPending) {
-        // If search parameters have not changed and nothing is pending
-        // Then trigger a refetch
-        refetchResults();
-      }
-    } else {
-      // Otherwise, set the new search parameters
-      // This will trigger a new fetch
-      setSearchParameters(search);
-    }
+  const debouncedSearchParams = useDebouncedValue(searchParams, 1000);
+
+  useEffect(
+    () => setSearchParameters(debouncedSearchParams),
+    [debouncedSearchParams]
+  );
+
+  // If search parameters have not changed and nothing is pending
+  // Then trigger a refetch
+  const handleSearch = () => {
+    if (!resultPending) refetchResults();
   };
 
   // https://react.dev/reference/react/useCallback#skipping-re-rendering-of-components
@@ -150,49 +126,55 @@ function Data(props: DataProps) {
 
   return (
     <Container fluid className="g-2">
-      <Stack gap={2}>
-        <RecordModal
-          {...props}
-          recordID={recordModalID}
-          show={recordModalShow}
-          onHide={handleRecordModalHide}
-        />
-        <SearchBar
-          {...props}
-          searchInput={searchInput}
-          setSearchInput={setSearchInput}
-          handleSearch={handleSearch}
-        />
-        <Row className="g-2">
-          <Col md={8}>
-            <FilterPanel
-              {...props}
-              filterList={filterList}
-              setFilterList={setFilterList}
-              filterFieldOptions={filterFieldOptions}
-            />
-          </Col>
-          <Col md={4}>
-            <TransformsPanel
-              {...props}
-              transform={transform}
-              setTransform={setTransform}
-              transformList={transformList}
-              setTransformList={setTransformList}
-              filterFieldOptions={filterFieldOptions}
-              listFieldOptions={listFieldOptions}
-            />
-          </Col>
-        </Row>
-        <ResultsPanel
-          {...props}
-          resultPending={resultPending}
-          resultError={resultError instanceof Error ? resultError : null}
-          resultData={resultData}
-          searchParameters={searchParameters}
-          handleRecordModalShow={handleRecordModalShow}
-        />
-      </Stack>
+      <RecordModal
+        {...props}
+        recordID={recordModalID}
+        show={recordModalShow}
+        onHide={handleRecordModalHide}
+      />
+      <div className="parent">
+        <div className="left-col">
+          <Container fluid className="g-2">
+            <Stack gap={2}>
+              <SearchBar
+                {...props}
+                searchInput={searchInput}
+                setSearchInput={setSearchInput}
+                handleSearch={handleSearch}
+              />
+              <FilterPanel
+                {...props}
+                filterList={filterList}
+                setFilterList={setFilterList}
+                filterFieldOptions={filterFieldOptions}
+              />
+              <TransformsPanel
+                {...props}
+                transform={transform}
+                setTransform={setTransform}
+                transformList={transformList}
+                setTransformList={setTransformList}
+                filterFieldOptions={filterFieldOptions}
+                listFieldOptions={listFieldOptions}
+              />
+            </Stack>
+          </Container>
+        </div>
+        <div className="right-col">
+          <Container fluid className="g-2">
+            {props.project && (
+              <ResultsPanel
+                {...props}
+                resultPending={resultPending}
+                resultError={resultError instanceof Error ? resultError : null}
+                resultData={resultData}
+                searchParameters={searchParameters}
+                handleRecordModalShow={handleRecordModalShow}
+              />
+            )}
+          </Container>
+        </div>
+      </div>
     </Container>
   );
 }

--- a/lib/pages/Data.tsx
+++ b/lib/pages/Data.tsx
@@ -135,7 +135,7 @@ function Data(props: DataProps) {
       <div className="parent h-100">
         <div className="left-col h-100">
           <Container fluid className="g-2 h-100">
-            <Stack gap={2} className="h-100">
+            <Stack gap={2} className="h-100 p-1">
               <SearchBar
                 {...props}
                 searchInput={searchInput}

--- a/lib/pages/Stats.tsx
+++ b/lib/pages/Stats.tsx
@@ -245,7 +245,6 @@ function Stats(props: StatsProps) {
   // Reset graphs when project changes
   useLayoutEffect(() => {
     setGraphConfigList(defaultGraphConfig());
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.project]);
 
   const handleGraphConfigTypeChange = (

--- a/lib/pages/Stats.tsx
+++ b/lib/pages/Stats.tsx
@@ -193,7 +193,7 @@ function GraphPanel(props: GraphPanelProps) {
                 </Button>
               </Stack>
             </Card.Header>
-            <Card.Body style={{ overflowY: "scroll" }}>
+            <Card.Body className="overflow-y-scroll">
               <GraphPanelOptions {...props} />
             </Card.Body>
           </Card>
@@ -317,8 +317,8 @@ function Stats(props: StatsProps) {
   };
 
   return (
-    <Container fluid className="g-2">
-      <Card>
+    <Container fluid className="g-2 h-100">
+      <Card className="h-100">
         <Card.Header>
           <span>Graphs</span>
           <Stack direction="horizontal" gap={1} className="float-end">
@@ -351,7 +351,7 @@ function Stats(props: StatsProps) {
             </DropdownButton>
           </Stack>
         </Card.Header>
-        <Container fluid className="onyx-graphs-panel-body p-2">
+        <Container fluid className="overflow-y-scroll p-2 h-100">
           <Row className="g-2">
             {graphConfigList.map((graphConfig, index) => (
               <Col key={graphConfig.key} lg={viewMode === "wide" ? 12 : 6}>

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -28,6 +28,13 @@ type ResultData = {
   messages?: ErrorType;
 };
 
+enum ExportStatus {
+  READY,
+  RUNNING,
+  FINISHED,
+  CANCELLED,
+}
+
 export type {
   ProjectField,
   FilterField,
@@ -36,3 +43,5 @@ export type {
   ErrorType,
   ResultData,
 };
+
+export { ExportStatus };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "climb-onyx-gui",
-  "version": "0.12.4",
+  "version": "0.12.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "climb-onyx-gui",
-      "version": "0.12.4",
+      "version": "0.12.9",
       "dependencies": {
-        "@ag-grid-community/client-side-row-model": "^32.1.0",
-        "@ag-grid-community/core": "^32.1.0",
-        "@ag-grid-community/react": "^32.1.0",
-        "@ag-grid-community/styles": "^32.1.0",
+        "@ag-grid-community/client-side-row-model": "^32.2.0",
+        "@ag-grid-community/core": "^32.2.0",
+        "@ag-grid-community/react": "^32.2.0",
+        "@ag-grid-community/styles": "^32.2.0",
         "@tanstack/react-query": "^4.36.1",
         "export-to-csv": "^1.3.0",
         "plotly.js-basic-dist": "^2.33.0",
@@ -22,8 +22,8 @@
       "devDependencies": {
         "@types/node": "^20.12.12",
         "@types/plotly.js-basic-dist": "^1.54.4",
-        "@types/react": "^18.2.66",
-        "@types/react-dom": "^18.2.22",
+        "@types/react": "^17.0.83",
+        "@types/react-dom": "^17.0.25",
         "@types/react-plotly.js": "^2.6.3",
         "@typescript-eslint/eslint-plugin": "^7.2.0",
         "@typescript-eslint/parser": "^7.2.0",
@@ -31,8 +31,8 @@
         "eslint": "^8.57.0",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-react-refresh": "^0.4.6",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0",
+        "react": "^17.0.2",
+        "react-dom": "^17.0.2",
         "typescript": "^5.2.2",
         "vite": "^5.2.0",
         "vite-plugin-dts": "^3.9.1"
@@ -43,43 +43,43 @@
       }
     },
     "node_modules/@ag-grid-community/client-side-row-model": {
-      "version": "32.1.0",
-      "resolved": "https://registry.npmjs.org/@ag-grid-community/client-side-row-model/-/client-side-row-model-32.1.0.tgz",
-      "integrity": "sha512-R/IA3chA/w9fy6/EeZhi42PTwVnb6bNjGMah1GWGvuNDTvfbPO4X9r4nhOMj6YH483bO+C7pPb4EoLECx0dfRQ==",
+      "version": "32.2.2",
+      "resolved": "https://registry.npmjs.org/@ag-grid-community/client-side-row-model/-/client-side-row-model-32.2.2.tgz",
+      "integrity": "sha512-BenXaVRISOAlMwl59BWGAJ/RBRsc0eHR3i/pGRmjQc8eGgdTqjrePL4kDL7UXDAKoqqNsoGKK5TGHjCHAs1cHA==",
       "license": "MIT",
       "dependencies": {
-        "@ag-grid-community/core": "32.1.0",
+        "@ag-grid-community/core": "32.2.2",
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@ag-grid-community/core": {
-      "version": "32.1.0",
-      "resolved": "https://registry.npmjs.org/@ag-grid-community/core/-/core-32.1.0.tgz",
-      "integrity": "sha512-fHpgSZa/aBjg2DdOzooDxILFZqxmxP8vsjRfeZVtqby19mTKwNAclE7Z6rWzOA0GYjgN9s8JwLFcNA5pvfswMg==",
+      "version": "32.2.2",
+      "resolved": "https://registry.npmjs.org/@ag-grid-community/core/-/core-32.2.2.tgz",
+      "integrity": "sha512-8w++Q5DKbFKhee7ZZ3HCx6KkMTHVwtV+xNwN/RJZneQ3WkXJYvsnkgVWmiwtglEo1iuMArxTz6pqOz/p23TBxA==",
       "license": "MIT",
       "dependencies": {
-        "ag-charts-types": "10.1.0",
+        "ag-charts-types": "10.2.0",
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@ag-grid-community/react": {
-      "version": "32.1.0",
-      "resolved": "https://registry.npmjs.org/@ag-grid-community/react/-/react-32.1.0.tgz",
-      "integrity": "sha512-ObaMk+g5IpfuiHSNar56IhJ0dLKkHaeMQYI9H1JlJyf5+3IafY1DiuGZ5mZTU7GyfNBgmMuRWrUxwOyt0tp7Lw==",
+      "version": "32.2.2",
+      "resolved": "https://registry.npmjs.org/@ag-grid-community/react/-/react-32.2.2.tgz",
+      "integrity": "sha512-stiWKeNO9sFjTzyssE+ZqPyiHB7wYY8qHgO4ykgEEzVQMU+8sNcagfR2eX4+zelpWUOpT3ku3KtCNy7GQWyXaA==",
       "license": "MIT",
       "dependencies": {
         "prop-types": "^15.8.1"
       },
       "peerDependencies": {
-        "@ag-grid-community/core": "32.1.0",
+        "@ag-grid-community/core": "32.2.2",
         "react": "^16.3.0 || ^17.0.0 || ^18.0.0",
         "react-dom": "^16.3.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@ag-grid-community/styles": {
-      "version": "32.1.0",
-      "resolved": "https://registry.npmjs.org/@ag-grid-community/styles/-/styles-32.1.0.tgz",
-      "integrity": "sha512-OjakLetS/zr0g5mJWpnjldk/RjGnl7Rv3I/5cGuvtgdmSgS+4FNZMr8ZmyR8Bl34s0RM63OSIphpVaFGlnJM4w==",
+      "version": "32.2.2",
+      "resolved": "https://registry.npmjs.org/@ag-grid-community/styles/-/styles-32.2.2.tgz",
+      "integrity": "sha512-YQm+Tb0yPUxxFmExrYtic+gMOU+00/brLZNVE8sB8/6SuxIKla6Vk7sC1aljtMtwaxO0H4gOL7vx4wYB4FtwBA==",
       "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
@@ -1225,15 +1225,17 @@
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/@react-aria/ssr": {
-      "version": "3.9.3",
-      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.3.tgz",
-      "integrity": "sha512-5bUZ93dmvHFcmfUcEN7qzYe8yQQ8JY+nHN6m9/iSDCQ/QmCiE0kWXYwhurjw5ch6I8WokQzx66xKIMHBAa4NNA==",
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.6.tgz",
+      "integrity": "sha512-iLo82l82ilMiVGy342SELjshuWottlb5+VefO3jOQqQRNYnJBFpUSadswDPbRimSgJUZuFwIEYs6AabkP038fA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@swc/helpers": "^0.5.0"
       },
@@ -1241,7 +1243,7 @@
         "node": ">= 12"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@restart/hooks": {
@@ -1256,9 +1258,10 @@
       }
     },
     "node_modules/@restart/ui": {
-      "version": "1.6.9",
-      "resolved": "https://registry.npmjs.org/@restart/ui/-/ui-1.6.9.tgz",
-      "integrity": "sha512-mUbygUsJcRurjZCt1f77gg4DpheD1D+Sc7J3JjAkysUj7t8m4EBJVOqWC9788Qtbc69cJ+HlJc6jBguKwS8Mcw==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@restart/ui/-/ui-1.8.0.tgz",
+      "integrity": "sha512-xJEOXUOTmT4FngTmhdjKFRrVVF0hwCLNPdatLCHkyS4dkiSK12cEu1Y0fjxktjJrdst9jJIc5J6ihMJCoWEN/g==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.21.0",
         "@popperjs/core": "^2.11.6",
@@ -1279,6 +1282,7 @@
       "version": "8.0.4",
       "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-8.0.4.tgz",
       "integrity": "sha512-ulRWYWHvscPFc0QQXvyJjY6LIXU56f0h8pQFvhxiKk5V1fcI8gp9Ht9leVAhrVjzqMw0BgjspBINx9r6oyJUvQ==",
+      "license": "MIT",
       "peerDependencies": {
         "react": ">=16.14.0"
       }
@@ -1839,21 +1843,24 @@
       "integrity": "sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q=="
     },
     "node_modules/@types/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-V0kuGBX3+prX+DQ/7r2qsv1NsdfnCLnTgnRJ1pYnxykBhGMz+qj+box5lq7XsO5mtZsBqpjwwTu/7wszPfMBcw==",
+      "version": "17.0.83",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.83.tgz",
+      "integrity": "sha512-l0m4ArKJvmFtR4e8UmKrj1pB4tUgOhJITf+mADyF/p69Ts1YAR/E+G9XEM0mHXKVRa1dQNHseyyDNzeuAXfXQw==",
+      "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
+        "@types/scheduler": "^0.16",
         "csstype": "^3.0.2"
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "18.3.0",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
-      "integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
+      "version": "17.0.25",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.25.tgz",
+      "integrity": "sha512-urx7A7UxkZQmThYA4So0NelOVjx3V4rNFVJwp0WZlbIK5eM4rNJDiN3R/E9ix0MBh6kAEojk/9YL+Te6D9zHNA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@types/react": "*"
+        "@types/react": "^17"
       }
     },
     "node_modules/@types/react-plotly.js": {
@@ -1874,6 +1881,12 @@
         "@types/react": "*"
       }
     },
+    "node_modules/@types/scheduler": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
+      "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==",
+      "license": "MIT"
+    },
     "node_modules/@types/semver": {
       "version": "7.5.8",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
@@ -1883,7 +1896,8 @@
     "node_modules/@types/warning": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.3.tgz",
-      "integrity": "sha512-D1XC7WK8K+zZEveUPY+cf4+kgauk8N4eHr/XIHXGlGYkHLud6hK9lYfZk1ry1TNh798cZUCgb6MqGEG8DkJt6Q=="
+      "integrity": "sha512-D1XC7WK8K+zZEveUPY+cf4+kgauk8N4eHr/XIHXGlGYkHLud6hK9lYfZk1ry1TNh798cZUCgb6MqGEG8DkJt6Q==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "7.8.0",
@@ -2203,9 +2217,9 @@
       }
     },
     "node_modules/ag-charts-types": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ag-charts-types/-/ag-charts-types-10.1.0.tgz",
-      "integrity": "sha512-pk9ft8hbgTXJ/thI/SEUR1BoauNplYExpcHh7tMOqVikoDsta1O15TB1ZL4XWnl4TPIzROBmONKsz7d8a2HBuQ==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ag-charts-types/-/ag-charts-types-10.2.0.tgz",
+      "integrity": "sha512-PUqH1QtugpYLnlbMdeSZVf5PpT1XZVsP69qN1JXhetLtQpVC28zaj7ikwu9CMA9N9b+dBboA9QcjUQUJZVUokQ==",
       "license": "MIT"
     },
     "node_modules/ajv": {
@@ -5129,11 +5143,13 @@
       }
     },
     "node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "license": "MIT",
       "dependencies": {
-        "loose-envify": "^1.1.0"
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -5169,15 +5185,17 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
+      "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+      "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
+        "object-assign": "^4.1.1",
+        "scheduler": "^0.20.2"
       },
       "peerDependencies": {
-        "react": "^18.3.1"
+        "react": "17.0.2"
       }
     },
     "node_modules/react-is": {
@@ -5226,6 +5244,7 @@
       "version": "4.4.5",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
       "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/runtime": "^7.5.5",
         "dom-helpers": "^5.0.1",
@@ -5510,11 +5529,13 @@
       "peer": true
     },
     "node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
+      "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+      "license": "MIT",
       "dependencies": {
-        "loose-envify": "^1.1.0"
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
       }
     },
     "node_modules/semver": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@ag-grid-community/client-side-row-model": "^32.2.0",
         "@ag-grid-community/core": "^32.2.0",
+        "@ag-grid-community/csv-export": "^32.2.0",
         "@ag-grid-community/react": "^32.2.0",
         "@ag-grid-community/styles": "^32.2.0",
         "@tanstack/react-query": "^4.36.1",
@@ -59,6 +60,16 @@
       "license": "MIT",
       "dependencies": {
         "ag-charts-types": "10.2.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@ag-grid-community/csv-export": {
+      "version": "32.2.2",
+      "resolved": "https://registry.npmjs.org/@ag-grid-community/csv-export/-/csv-export-32.2.2.tgz",
+      "integrity": "sha512-9ttdlJ7XOgK/qGC0QyXM1ep3f1GIjnyz1cQqIr9B2epe0fGFDt+lvK9EJBAQCG2GVJaFJ/xxBJfkQx65ganp+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@ag-grid-community/core": "32.2.2",
         "tslib": "^2.3.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@ag-grid-community/client-side-row-model": "^32.2.0",
     "@ag-grid-community/core": "^32.2.0",
+    "@ag-grid-community/csv-export": "^32.2.0",
     "@ag-grid-community/react": "^32.2.0",
     "@ag-grid-community/styles": "^32.2.0",
     "@tanstack/react-query": "^4.36.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "climb-onyx-gui",
-  "version": "0.12.4",
+  "version": "0.12.9",
   "type": "module",
   "main": "dist/climb-onyx-gui.js",
   "types": "dist/main.d.ts",
@@ -18,10 +18,10 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@ag-grid-community/client-side-row-model": "^32.1.0",
-    "@ag-grid-community/core": "^32.1.0",
-    "@ag-grid-community/react": "^32.1.0",
-    "@ag-grid-community/styles": "^32.1.0",
+    "@ag-grid-community/client-side-row-model": "^32.2.0",
+    "@ag-grid-community/core": "^32.2.0",
+    "@ag-grid-community/react": "^32.2.0",
+    "@ag-grid-community/styles": "^32.2.0",
     "@tanstack/react-query": "^4.36.1",
     "export-to-csv": "^1.3.0",
     "plotly.js-basic-dist": "^2.33.0",
@@ -36,8 +36,8 @@
   "devDependencies": {
     "@types/node": "^20.12.12",
     "@types/plotly.js-basic-dist": "^1.54.4",
-    "@types/react": "^18.2.66",
-    "@types/react-dom": "^18.2.22",
+    "@types/react": "^17.0.83",
+    "@types/react-dom": "^17.0.25",
     "@types/react-plotly.js": "^2.6.3",
     "@typescript-eslint/eslint-plugin": "^7.2.0",
     "@typescript-eslint/parser": "^7.2.0",
@@ -45,8 +45,8 @@
     "eslint": "^8.57.0",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.6",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
     "typescript": "^5.2.2",
     "vite": "^5.2.0",
     "vite-plugin-dts": "^3.9.1"

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,12 +1,13 @@
 import React from "react";
-import ReactDOM from "react-dom/client";
+import ReactDOM from "react-dom";
 import Onyx from "../lib/Onyx.tsx";
 import { httpPathHandler, fileWriter } from "./handlers.tsx";
 
 import "./font.css";
 
-ReactDOM.createRoot(document.getElementById("root")!).render(
+ReactDOM.render(
   <React.StrictMode>
     <Onyx httpPathHandler={httpPathHandler} fileWriter={fileWriter} />
-  </React.StrictMode>
+  </React.StrictMode>,
+  document.getElementById("root")
 );


### PR DESCRIPTION
### Changes
This PR has morphed into a few more features than originally intended:

- Merged common logic from both server-side paginated tables and client-side unpaginated tables into a `BaseTable`.
- Table options dropdown, containing commands for data export, column unpinning, filter resetting and column state resetting.
- Export modal with general interface used for exporting CSV and JSON data, with progress bar indicator for paginated data, cancellation functionality for paginated data, and file name generation/validation.
- Github actions for verifying project builds and lints correctly.
- Data page UI has undergone a large change, with the filter/summarise functionality shifted to a resizable left column. This allows a much larger view on the data tables itself, while still being flexible in the view/editing of filters.
- Data page also now uses debouncing to auto-refresh the displayed data as users update their query. No need to click the 'search' button anymore - and this prevents potential confusion with data export, where un-searched filters would not match the exported data.
- The app has been refactored to use 100% viewport (in most cases) successfully, meaning no need to define arbitrary view heights to work in Jupyterlab.
- Dark mode preference is saved in localStorage.

### Still todo
A couple of things are required still before the next release:

- Async handlers in `onyx-extension` for file + s3 operations - need some form of GUI success/error handling rather than console logging.
- Black background does not extend when viewport goes beyond 100% (which sometimes happens and looks bad).
- New Data page UI looks bad on smaller breakpoints. 