### PR TITLE
Removed GUI version number from `Header`, using single extension version number

### DIFF
--- a/lib/Onyx.tsx
+++ b/lib/Onyx.tsx
@@ -31,8 +31,6 @@ import "@fontsource/ibm-plex-sans";
 import "./Onyx.css";
 import "./bootstrap.css";
 
-const VERSION = "0.13.0";
-
 function App(props: OnyxProps) {
   const [darkMode, setDarkMode] = useState(
     localStorage.getItem("onyx-theme") === "dark"
@@ -182,7 +180,6 @@ function App(props: OnyxProps) {
         }
         projectList={projects}
         handleProjectChange={handleProjectChange}
-        guiVersion={VERSION}
         tabKey={tabKey}
         setTabKey={setTabKey}
         darkMode={darkMode}

--- a/lib/components/Header.tsx
+++ b/lib/components/Header.tsx
@@ -14,8 +14,6 @@ interface HeaderProps extends PageProps {
   projectName: string;
   projectList: string[];
   handleProjectChange: (p: string) => void;
-  guiVersion?: string;
-  extVersion?: string;
   tabKey: string;
   setTabKey: (k: string) => void;
   handleThemeChange: () => void;
@@ -90,7 +88,6 @@ function Header(props: HeaderProps) {
       }}
       className="border-bottom onyx-border"
       variant="dark"
-      collapseOnSelect
       expand="lg"
       fixed="top"
     >
@@ -103,8 +100,8 @@ function Header(props: HeaderProps) {
           >
             <MdJoinInner color="var(--bs-pink)" /> Onyx
           </Navbar.Brand>
-          <Navbar.Toggle aria-controls="header" />
-          <Navbar.Collapse id="header">
+          <Navbar.Toggle aria-controls="responsive-navbar-nav" />
+          <Navbar.Collapse id="responsive-navbar-nav">
             <Nav className="me-auto">
               <NavDropdown
                 title={<HeaderText label="Project" value={props.projectName} />}
@@ -121,68 +118,59 @@ function Header(props: HeaderProps) {
               </NavDropdown>
               <Nav variant="underline">
                 <Stack direction="horizontal" gap={3}>
-                  <Nav.Item>
-                    <Nav.Link eventKey="user" className="fw-normal">
-                      <HeaderText
-                        label="User"
-                        value={
-                          isFetching
-                            ? "Loading..."
-                            : error
-                            ? "Failed to load"
-                            : profile.username
-                        }
-                      />
-                    </Nav.Link>
-                  </Nav.Item>
-                  <Nav.Item>
-                    <Nav.Link eventKey="site" className="fw-normal">
-                      <HeaderText
-                        label="Site"
-                        value={
-                          isFetching
-                            ? "Loading..."
-                            : error
-                            ? "Failed to load"
-                            : profile.site
-                        }
-                      />
-                    </Nav.Link>
-                  </Nav.Item>
-                  <HeaderVersion label="GUI" version={props.guiVersion} />
-                  <HeaderVersion label="Extension" version={props.extVersion} />
+                  <Nav.Link eventKey="user" className="fw-normal">
+                    <HeaderText
+                      label="User"
+                      value={
+                        isFetching
+                          ? "Loading..."
+                          : error
+                          ? "Failed to load"
+                          : profile.username
+                      }
+                    />
+                  </Nav.Link>
+                  <Nav.Link eventKey="site" className="fw-normal">
+                    <HeaderText
+                      label="Site"
+                      value={
+                        isFetching
+                          ? "Loading..."
+                          : error
+                          ? "Failed to load"
+                          : profile.site
+                      }
+                    />
+                  </Nav.Link>
+                  <Nav.Link disabled className="fw-normal ">
+                    <HeaderVersion label="Version" version={props.extVersion} />
+                  </Nav.Link>
                 </Stack>
               </Nav>
             </Nav>
             <Nav variant="underline">
               <Stack direction="horizontal" gap={3}>
-                <Nav.Item>
-                  <Nav.Link
-                    eventKey="records"
-                    className="fw-normal"
-                    active={
-                      props.tabKey === "records" || props.tabKey === "record"
-                    }
-                  >
-                    Records
-                  </Nav.Link>
-                </Nav.Item>
-                <Nav.Item>
-                  <Nav.Link
-                    eventKey="analyses"
-                    className="fw-normal"
-                    active={
-                      props.tabKey === "analyses" || props.tabKey === "analysis"
-                    }
-                  >
-                    Analyses
-                  </Nav.Link>
-                </Nav.Item>
-                <Nav.Item>
-                  <Nav.Link eventKey="graphs" className="fw-normal">
-                    Graphs
-                  </Nav.Link>
-                </Nav.Item>
+                <Nav.Link
+                  eventKey="records"
+                  className="fw-normal"
+                  active={
+                    props.tabKey === "records" || props.tabKey === "record"
+                  }
+                >
+                  Records
+                </Nav.Link>
+                <Nav.Link
+                  eventKey="analyses"
+                  className="fw-normal"
+                  active={
+                    props.tabKey === "analyses" || props.tabKey === "analysis"
+                  }
+                >
+                  Analyses
+                </Nav.Link>
+                <Nav.Link eventKey="graphs" className="fw-normal">
+                  Graphs
+                </Nav.Link>
                 <Form.Check
                   type="switch"
                   id="theme-switch"

--- a/lib/interfaces.ts
+++ b/lib/interfaces.ts
@@ -4,7 +4,7 @@ interface OnyxProps {
   httpPathHandler: (path: string) => Promise<Response>;
   s3PathHandler: (path: string) => Promise<void>;
   fileWriter: (path: string, content: string) => Promise<void>;
-  extVersion?: string;
+  extVersion: string;
 }
 
 interface ProjectProps extends OnyxProps {

--- a/src/handlers.tsx
+++ b/src/handlers.tsx
@@ -21,4 +21,6 @@ function fileWriter(path: string, content: string) {
   });
 }
 
-export { fileWriter, httpPathHandler, s3PathHandler };
+const extVersion = import.meta.env.VITE_ONYX_VERSION;
+
+export { fileWriter, httpPathHandler, s3PathHandler, extVersion };

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,12 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import Onyx from "../lib/Onyx.tsx";
-import { fileWriter, httpPathHandler, s3PathHandler } from "./handlers.tsx";
+import {
+  fileWriter,
+  httpPathHandler,
+  s3PathHandler,
+  extVersion,
+} from "./handlers.tsx";
 
 import "./font.css";
 
@@ -11,6 +16,7 @@ ReactDOM.render(
       httpPathHandler={httpPathHandler}
       s3PathHandler={s3PathHandler}
       fileWriter={fileWriter}
+      extVersion={extVersion}
     />
   </React.StrictMode>,
   document.getElementById("root")


### PR DESCRIPTION
- Removed the GUI version number from display, now only displays the value provided to `extVersion`.
- This is done because the user only needs to see the end version number of the JupyterLab extension - its confusing otherwise.
-  Removed `collapseOnSelect` because it doesn't work with `TabContainer`.
- Cleaned up some redundant HTML in the `Header` component.
- Made `extVersion` a required argument to `Onyx`.
- Added local dev `VITE_ONYX_VERSION` environment variable. 