### PR TITLE
Fixed bug in `useQueryRefresh`

### DIFF
--- a/lib/components/Graphs.tsx
+++ b/lib/components/Graphs.tsx
@@ -37,7 +37,7 @@ interface BaseGraphProps extends BasePlotProps {
 
 interface GraphProps extends DataProps {
   graphConfig: GraphConfig;
-  refresh: number;
+  refresh: number | null;
   setLastUpdated: (lastUpdated: string | null) => void;
 }
 

--- a/lib/pages/Graphs.tsx
+++ b/lib/pages/Graphs.tsx
@@ -53,7 +53,7 @@ interface GraphPanelProps extends DataProps {
   showOptions: boolean;
   firstGraph: boolean;
   lastGraph: boolean;
-  refresh: number;
+  refresh: number | null;
 }
 
 interface GraphPanelGraphProps extends GraphPanelProps {
@@ -388,7 +388,7 @@ function Graphs(props: DataProps) {
     .map(([field]) => field);
   const [viewMode, setViewMode] = useState<"list" | "grid">("list");
   const [showOptions, setShowOptions] = useState(true);
-  const [refresh, setRefresh] = useState(0);
+  const [refresh, setRefresh] = useState<number | null>(null);
 
   const handleRefresh = () => {
     setRefresh(refresh ? 0 : 1);

--- a/lib/utils/hooks.ts
+++ b/lib/utils/hooks.ts
@@ -14,13 +14,14 @@ const useDebouncedValue = (inputValue: string, delay: number) => {
 };
 
 const useQueryRefresh = (
-  refresh: number,
+  refresh: number | null,
   dataUpdatedAt: number,
   errorUpdatedAt: number,
   refetch: () => void,
   setLastUpdated: (lastUpdated: string | null) => void
 ) => {
   useEffect(() => {
+    if (refresh === null) return;
     refetch();
   }, [refetch, refresh]);
 

--- a/lib/utils/hooks.ts
+++ b/lib/utils/hooks.ts
@@ -21,6 +21,9 @@ const useQueryRefresh = (
   setLastUpdated: (lastUpdated: string | null) => void
 ) => {
   useEffect(() => {
+    // The refresh value begins as null, and is set to a number when the user clicks the refresh button.
+    // It then alternates between 0 and 1 on every refresh click, to trigger the refetch in this useEffect.
+    // If the refresh value is null, then the user has not clicked the refresh button, and we do not want to refetch.
     if (refresh === null) return;
     refetch();
   }, [refetch, refresh]);

--- a/src/handlers.tsx
+++ b/src/handlers.tsx
@@ -3,8 +3,12 @@ function delay(ms: number) {
 }
 
 function httpPathHandler(path: string) {
-  return fetch(import.meta.env.VITE_ONYX_DOMAIN + path, {
-    headers: { Authorization: "Token " + import.meta.env.VITE_ONYX_TOKEN },
+  const domain = import.meta.env.VITE_ONYX_DOMAIN || "";
+  const token = import.meta.env.VITE_ONYX_TOKEN || "";
+  return fetch(domain + path, {
+    headers: {
+      Authorization: "Token " + token,
+    },
   });
 }
 
@@ -21,6 +25,6 @@ function fileWriter(path: string, content: string) {
   });
 }
 
-const extVersion = import.meta.env.VITE_ONYX_VERSION;
+const extVersion = import.meta.env.VITE_ONYX_VERSION || "";
 
 export { fileWriter, httpPathHandler, s3PathHandler, extVersion };


### PR DESCRIPTION
# Changes

- Previously, there existed a bug where the `useSummaryQuery` and `useGroupedSummaryQuery` were being triggered even when no project existed, despite both queries containing an `enabled: !!project` requirement.
- This was due to the `useQueryRefresh` effect, which wraps a `useEffect` that depends on the query's `refetch` function as well as a `refresh` number value that determines when to refresh the graphs. But this was being triggered regardless, I assume due to the object reference of `refresh` changing in the effects dependency array. Triggering the refetch function overrides any enabled requirements on the query hence the issue.
- This bug was fixed by having the initial state of `refresh` be `null`, and have the effect only trigger the refetch if the `refresh` value is not null. `refresh` only becomes a number once a user clicks the button to refresh graphs, with the state then alternating between `0` and `1` on each click, successfully handling refresh triggering.