### PR TITLE
Fixed bug with HTTP response failure handling on table export+pagination

### DIFF
--- a/lib/components/Table.tsx
+++ b/lib/components/Table.tsx
@@ -25,6 +25,7 @@ import { useCountQuery } from "../api";
 import { ExportHandlerProps, OnyxProps } from "../interfaces";
 import { ExportStatus, ListResponse } from "../types";
 import ExportModal from "./ExportModal";
+import { formatResponseStatus } from "../utils/functions";
 
 ModuleRegistry.registerModules([ClientSideRowModelModule, CsvExportModule]);
 
@@ -281,7 +282,10 @@ function TableOptions(props: TableOptionsProps) {
     while (search instanceof URLSearchParams) {
       await props
         .httpPathHandler(`${props.searchPath}/?${search.toString()}`)
-        .then((response) => response.json())
+        .then((response) => {
+          if (!response.ok) throw new Error(formatResponseStatus(response));
+          return response.json();
+        })
         .then((response: ListResponse) => {
           if (exportProps.statusToken.status === ExportStatus.CANCELLED)
             throw new Error("export_cancelled");
@@ -626,7 +630,10 @@ function ServerPaginatedTable(props: ServerPaginatedTableProps) {
 
       props
         .httpPathHandler(`${props.searchPath}/?${search.toString()}`)
-        .then((response) => response.json())
+        .then((response) => {
+          if (!response.ok) throw new Error(formatResponseStatus(response));
+          return response.json();
+        })
         .then((response) => handleResponse(response, resultsPage, userPage))
         .finally(() => setLoading(false));
     } else {

--- a/lib/utils/functions.ts
+++ b/lib/utils/functions.ts
@@ -63,8 +63,14 @@ function formatFilters(filters: FilterConfig[]) {
     });
 }
 
+/** Takes a Response object and returns its status code, formatted as a string. */
+function formatResponseStatus(response: Response) {
+  return `${response.status} (${response.statusText})`;
+}
+
 export {
   formatFilters,
+  formatResponseStatus,
   generateKey,
   getDefaultFileNamePrefix,
   handleJSONExport,


### PR DESCRIPTION
* Fixed issue with `httpPathHandler` error handling in `Table` component pagination and page change, where `4XX` status codes were not thrown as errors leading to a `data is undefined` error on failure, rather than something more informative.
* Now displays the correct status code and message on error.