### PR TITLE
Added dynamic progress message for data export

### DIFF
--- a/lib/components/DataPanel.tsx
+++ b/lib/components/DataPanel.tsx
@@ -109,7 +109,6 @@ function DataPanel(props: DataPanelProps) {
           onHide={() => setExportModalShow(false)}
           defaultFileNamePrefix={props.ID}
           defaultFileExtension=".json"
-          exportProgressMessage={`Exporting ${props.ID} to JSON...`}
           handleExport={handleJSONExport(jsonExportProps)}
         />
         <Row className="h-100">

--- a/lib/components/ExportModal.tsx
+++ b/lib/components/ExportModal.tsx
@@ -11,6 +11,7 @@ import Stack from "react-bootstrap/Stack";
 import { ExportHandlerProps } from "../interfaces";
 import { ExportStatus } from "../types";
 import { ErrorModalContents } from "./ErrorModal";
+import { defaultExportProgressMessage } from "../utils/messages";
 
 interface ExportModalProps {
   show: boolean;
@@ -18,7 +19,6 @@ interface ExportModalProps {
   defaultFileNamePrefix: string;
   defaultFileExtension: string;
   fileExtensions?: string[];
-  exportProgressMessage: string;
   handleExport: (exportProps: ExportHandlerProps) => void;
 }
 
@@ -47,6 +47,9 @@ function isInvalidPrefix(prefix: string) {
 function ExportModal(props: ExportModalProps) {
   const [exportStatus, setExportStatus] = useState(ExportStatus.READY);
   const [exportProgress, setExportProgress] = useState(0);
+  const [exportProgressMessage, setExportProgressMessage] = useState(
+    defaultExportProgressMessage
+  );
   const [exportError, setExportError] = useState<Error | null>(null);
   const [fileNamePrefix, setFileNamePrefix] = useState("");
   const [fileNameIsInvalid, setFileNameIsInvalid] = useState(false);
@@ -66,6 +69,7 @@ function ExportModal(props: ExportModalProps) {
     } else setFileNameIsInvalid(false);
 
     setExportProgress(0);
+    setExportProgressMessage(defaultExportProgressMessage);
     setExportError(null);
     readyExport();
     props.handleExport({
@@ -73,6 +77,7 @@ function ExportModal(props: ExportModalProps) {
       statusToken,
       setExportStatus,
       setExportProgress,
+      setExportProgressMessage,
       setExportError,
     });
   };
@@ -153,7 +158,7 @@ function ExportModal(props: ExportModalProps) {
         {exportStatus === ExportStatus.RUNNING && (
           <Form.Group className="mb-3">
             <Form.Label className="d-flex justify-content-center">
-              {props.exportProgressMessage}
+              {exportProgressMessage}
             </Form.Label>
             <ProgressBar now={exportProgress} />
           </Form.Group>

--- a/lib/components/Table.tsx
+++ b/lib/components/Table.tsx
@@ -300,6 +300,9 @@ function TableOptions(props: TableOptionsProps) {
           exportProps.setExportProgress(
             (nRows / props.rowDisplayParams.of) * 100
           );
+          exportProps.setExportProgressMessage(
+            `Fetched ${nRows.toLocaleString()}/${props.rowDisplayParams.of.toLocaleString()} items...`
+          );
         });
     }
 
@@ -370,7 +373,6 @@ function TableOptions(props: TableOptionsProps) {
         show={exportModalShow}
         handleExport={handleCSVExport}
         onHide={() => setExportModalShow(false)}
-        exportProgressMessage={`Fetching ${props.rowDisplayParams.of.toLocaleString()} items...`}
       />
       <DropdownButton
         id="table-options"

--- a/lib/components/Table.tsx
+++ b/lib/components/Table.tsx
@@ -25,6 +25,7 @@ import { useCountQuery } from "../api";
 import { ExportHandlerProps, OnyxProps } from "../interfaces";
 import { ExportStatus, ListResponse } from "../types";
 import ExportModal from "./ExportModal";
+import { formatResponseStatus } from "../utils/functions";
 
 ModuleRegistry.registerModules([ClientSideRowModelModule, CsvExportModule]);
 
@@ -281,7 +282,10 @@ function TableOptions(props: TableOptionsProps) {
     while (search instanceof URLSearchParams) {
       await props
         .httpPathHandler(`${props.searchPath}/?${search.toString()}`)
-        .then((response) => response.json())
+        .then((response) => {
+          if (!response.ok) throw new Error(formatResponseStatus(response));
+          return response.json();
+        })
         .then((response: ListResponse) => {
           if (exportProps.statusToken.status === ExportStatus.CANCELLED)
             throw new Error("export_cancelled");
@@ -626,7 +630,10 @@ function ServerPaginatedTable(props: ServerPaginatedTableProps) {
 
       props
         .httpPathHandler(`${props.searchPath}/?${search.toString()}`)
-        .then((response) => response.json())
+        .then((response) => {
+          if (!response.ok) throw new Error(formatResponseStatus(response));
+          return response.json();
+        })
         .then((response) => handleResponse(response, resultsPage, userPage))
         .finally(() => setLoading(false));
     } else {

--- a/lib/interfaces.ts
+++ b/lib/interfaces.ts
@@ -42,8 +42,8 @@ export interface ResultsProps extends DataProps {
 export interface ExportHandlerProps {
   fileName: string;
   statusToken: { status: ExportStatus };
-  setExportStatus: (exportStatus: ExportStatus) => void;
-  setExportProgress: (exportProgress: number) => void;
+  setExportStatus: (status: ExportStatus) => void;
+  setExportProgress: (progress: number) => void;
   setExportProgressMessage: (message: string) => void;
   setExportError: (error: Error) => void;
 }

--- a/lib/interfaces.ts
+++ b/lib/interfaces.ts
@@ -44,5 +44,6 @@ export interface ExportHandlerProps {
   statusToken: { status: ExportStatus };
   setExportStatus: (exportStatus: ExportStatus) => void;
   setExportProgress: (exportProgress: number) => void;
+  setExportProgressMessage: (message: string) => void;
   setExportError: (error: Error) => void;
 }

--- a/lib/utils/functions.ts
+++ b/lib/utils/functions.ts
@@ -63,8 +63,14 @@ function formatFilters(filters: FilterConfig[]) {
     });
 }
 
+/** Takes a Response object and returns its status code, formatted as a string. */
+function formatResponseStatus(response: Response) {
+  return `${response.status} (${response.statusText})`;
+}
+
 export {
   formatFilters,
+  formatResponseStatus,
   generateKey,
   getDefaultFileNamePrefix,
   handleJSONExport,

--- a/lib/utils/messages.ts
+++ b/lib/utils/messages.ts
@@ -6,3 +6,5 @@ export const recentActivityMessage =
 
 export const errorModalMessage =
   "Please try again or contact CLIMB-TRE support if the problem persists.";
+
+export const defaultExportProgressMessage = "Fetching items...";


### PR DESCRIPTION
* Replaced `exportProgressMessage` prop from `ExportModal` with inner state that can be set alongside `exportProgress` value.
* A `setExportProgressMessage` prop has been added to `ExportHandlerProps`, which now enables updating the message dynamically during export.
* In the case of CSV/TSV exports, an incrementing counter of the number of items fetched is now displayed.