### PR TITLE
Fix: Bug with unpublished badge being displayed

### DIFF
--- a/lib/components/DataPanel.tsx
+++ b/lib/components/DataPanel.tsx
@@ -72,7 +72,7 @@ function DataPanel(props: DataPanelProps) {
   }, [data, props.projectFields]);
 
   useEffect(() => {
-    if (data?.status === "success" && !data.data.is_published)
+    if (data?.status === "success" && data.data.is_published === false)
       props.setUnpublished();
   }, [data, props]);
 


### PR DESCRIPTION
- When the `is_published` field is not present in the metadata, the badge should not be displayed.