### PR TITLE
Better lazy loading, cleaner tab transitions

### DIFF
--- a/lib/Onyx.tsx
+++ b/lib/Onyx.tsx
@@ -200,10 +200,12 @@ function App(props: OnyxProps) {
         setTabKey={setTabKey}
         darkMode={darkMode}
         handleThemeChange={handleThemeChange}
+        handleProjectRecordHide={handleProjectRecordHide}
+        handleAnalysisHide={handleAnalysisHide}
       />
       <div className="h-100" style={{ paddingTop: "60px" }}>
         <Container fluid className="h-100 p-2">
-          <Tab.Container activeKey={tabKey} mountOnEnter>
+          <Tab.Container activeKey={tabKey} mountOnEnter transition={false}>
             <Tab.Content className="h-100">
               <Tab.Pane eventKey={OnyxTabKeys.USER} className="h-100">
                 <User {...props} project={project} darkMode={darkMode} />
@@ -212,7 +214,7 @@ function App(props: OnyxProps) {
                 <Site {...props} project={project} darkMode={darkMode} />
               </Tab.Pane>
               <Tab.Pane eventKey={OnyxTabKeys.RECORDS} className="h-100">
-                <Tab.Container activeKey={recordTabKey}>
+                <Tab.Container activeKey={recordTabKey} transition={false}>
                   <Tab.Content className="h-100">
                     <Tab.Pane eventKey={RecordTabKeys.LIST} className="h-100">
                       <Results
@@ -254,7 +256,7 @@ function App(props: OnyxProps) {
                 </Tab.Container>
               </Tab.Pane>
               <Tab.Pane eventKey={OnyxTabKeys.ANALYSES} className="h-100">
-                <Tab.Container activeKey={analysisTabKey}>
+                <Tab.Container activeKey={analysisTabKey} transition={false}>
                   <Tab.Content className="h-100">
                     <Tab.Pane eventKey={AnalysisTabKeys.LIST} className="h-100">
                       <Results

--- a/lib/Onyx.tsx
+++ b/lib/Onyx.tsx
@@ -20,10 +20,13 @@ import Site from "./pages/Site";
 import User from "./pages/User";
 import {
   AnalysisTabKeys,
+  AnalysisDetailTabKeys,
   DataPanelTabKeys,
   LookupObject,
+  OnyxTabKeys,
   ProjectPermissionType,
   RecordTabKeys,
+  RecordDetailTabKeys,
   TypeObject,
 } from "./types";
 
@@ -32,22 +35,33 @@ import "./Onyx.css";
 import "./bootstrap.css";
 
 function App(props: OnyxProps) {
+  // Global app state
   const [darkMode, setDarkMode] = useState(
     localStorage.getItem("onyx-theme") === "dark"
   );
   const [project, setProject] = useState("");
-  const [tabKey, setTabKey] = useState("records");
+  const [tabKey, setTabKey] = useState<string>(OnyxTabKeys.RECORDS);
+
+  // Record tab state
+  const [recordTabKey, setRecordTabKey] = useState<string>(RecordTabKeys.LIST);
   const [recordID, setRecordID] = useState("");
-  const [recordTabKey, setRecordTabKey] = useState<string>(RecordTabKeys.Data);
+  const [recordDetailTabKey, setRecordDetailTabKey] = useState<string>(
+    RecordDetailTabKeys.DATA
+  );
   const [recordDataPanelTabKey, setRecordDataPanelTabKey] = useState<string>(
-    DataPanelTabKeys.Details
+    DataPanelTabKeys.DETAILS
+  );
+
+  // Analysis tab state
+  const [analysisTabKey, setAnalysisTabKey] = useState<string>(
+    AnalysisTabKeys.LIST
   );
   const [analysisID, setAnalysisID] = useState("");
-  const [analysisTabKey, setAnalysisTabKey] = useState<string>(
-    AnalysisTabKeys.Data
+  const [analysisDetailTabKey, setAnalysisDetailTabKey] = useState<string>(
+    AnalysisDetailTabKeys.DATA
   );
   const [analysisDataPanelTabKey, setAnalysisDataPanelTabKey] =
-    useState<string>(DataPanelTabKeys.Details);
+    useState<string>(DataPanelTabKeys.DETAILS);
 
   // Set the theme based on darkMode state
   useEffect(() => {
@@ -63,7 +77,9 @@ function App(props: OnyxProps) {
 
   // Clear parameters when project changes
   const handleProjectChange = (project: string) => {
-    setTabKey("records");
+    setTabKey(OnyxTabKeys.RECORDS);
+    setRecordTabKey(RecordTabKeys.LIST);
+    setAnalysisTabKey(AnalysisTabKeys.LIST);
     setRecordID("");
     setAnalysisID("");
     setProject(project);
@@ -143,27 +159,27 @@ function App(props: OnyxProps) {
   // Usage of useCallback here prevents excessive re-rendering of the ResultsPanel
   // This noticeably improves responsiveness for large datasets
   const handleProjectRecordShow = useCallback((climbID: string) => {
-    setTabKey("record");
-    setRecordTabKey(RecordTabKeys.Data);
-    setRecordDataPanelTabKey(DataPanelTabKeys.Details);
+    setTabKey(OnyxTabKeys.RECORDS);
+    setRecordTabKey(RecordTabKeys.DETAIL);
+    setRecordDetailTabKey(RecordDetailTabKeys.DATA);
+    setRecordDataPanelTabKey(DataPanelTabKeys.DETAILS);
     setRecordID(climbID);
   }, []);
 
   const handleProjectRecordHide = useCallback(() => {
-    setTabKey("records");
-    setRecordID("");
+    setRecordTabKey(RecordTabKeys.LIST);
   }, []);
 
   const handleAnalysisShow = useCallback((analysisID: string) => {
-    setTabKey("analysis");
-    setAnalysisTabKey(AnalysisTabKeys.Data);
-    setAnalysisDataPanelTabKey(DataPanelTabKeys.Details);
+    setTabKey(OnyxTabKeys.ANALYSES);
+    setAnalysisTabKey(AnalysisTabKeys.DETAIL);
+    setAnalysisDetailTabKey(AnalysisDetailTabKeys.DATA);
+    setAnalysisDataPanelTabKey(DataPanelTabKeys.DETAILS);
     setAnalysisID(analysisID);
   }, []);
 
   const handleAnalysisHide = useCallback(() => {
-    setTabKey("analyses");
-    setAnalysisID("");
+    setAnalysisTabKey(AnalysisTabKeys.LIST);
   }, []);
 
   return (
@@ -184,86 +200,102 @@ function App(props: OnyxProps) {
         setTabKey={setTabKey}
         darkMode={darkMode}
         handleThemeChange={handleThemeChange}
-        recordID={recordID}
-        handleProjectRecordHide={handleProjectRecordHide}
-        analysisID={analysisID}
-        handleAnalysisHide={handleAnalysisHide}
       />
       <div className="h-100" style={{ paddingTop: "60px" }}>
         <Container fluid className="h-100 p-2">
           <Tab.Container activeKey={tabKey} mountOnEnter>
             <Tab.Content className="h-100">
-              <Tab.Pane eventKey="user" className="h-100">
+              <Tab.Pane eventKey={OnyxTabKeys.USER} className="h-100">
                 <User {...props} project={project} darkMode={darkMode} />
               </Tab.Pane>
-              <Tab.Pane eventKey="site" className="h-100">
+              <Tab.Pane eventKey={OnyxTabKeys.SITE} className="h-100">
                 <Site {...props} project={project} darkMode={darkMode} />
               </Tab.Pane>
-              <Tab.Pane eventKey="records" className="h-100">
-                <Results
-                  {...pageProps}
-                  projectFields={projectFields}
-                  projectDescription={projectDescription}
-                  typeLookups={typeLookups}
-                  fieldDescriptions={fieldDescriptions}
-                  lookupDescriptions={lookupDescriptions}
-                  handleProjectRecordShow={handleProjectRecordShow}
-                  handleAnalysisShow={handleAnalysisShow}
-                  title="Records"
-                  searchPath={`projects/${project}`}
-                />
+              <Tab.Pane eventKey={OnyxTabKeys.RECORDS} className="h-100">
+                <Tab.Container activeKey={recordTabKey}>
+                  <Tab.Content className="h-100">
+                    <Tab.Pane eventKey={RecordTabKeys.LIST} className="h-100">
+                      <Results
+                        {...pageProps}
+                        projectFields={projectFields}
+                        projectDescription={projectDescription}
+                        typeLookups={typeLookups}
+                        fieldDescriptions={fieldDescriptions}
+                        lookupDescriptions={lookupDescriptions}
+                        handleProjectRecordShow={handleProjectRecordShow}
+                        handleAnalysisShow={handleAnalysisShow}
+                        title="Records"
+                        searchPath={`projects/${project}`}
+                      />
+                    </Tab.Pane>
+                    <Tab.Pane
+                      eventKey={RecordTabKeys.DETAIL}
+                      className="h-100"
+                      unmountOnExit
+                    >
+                      <ProjectRecord
+                        {...pageProps}
+                        projectFields={projectFields}
+                        projectDescription={projectDescription}
+                        typeLookups={typeLookups}
+                        fieldDescriptions={fieldDescriptions}
+                        lookupDescriptions={lookupDescriptions}
+                        handleProjectRecordShow={handleProjectRecordShow}
+                        handleAnalysisShow={handleAnalysisShow}
+                        ID={recordID}
+                        tabKey={recordDetailTabKey}
+                        setTabKey={setRecordDetailTabKey}
+                        dataPanelTabKey={recordDataPanelTabKey}
+                        setDataPanelTabKey={setRecordDataPanelTabKey}
+                        onHide={handleProjectRecordHide}
+                      />
+                    </Tab.Pane>
+                  </Tab.Content>
+                </Tab.Container>
               </Tab.Pane>
-              <Tab.Pane eventKey="record" className="h-100">
-                <ProjectRecord
-                  {...pageProps}
-                  projectFields={projectFields}
-                  projectDescription={projectDescription}
-                  typeLookups={typeLookups}
-                  fieldDescriptions={fieldDescriptions}
-                  lookupDescriptions={lookupDescriptions}
-                  handleProjectRecordShow={handleProjectRecordShow}
-                  handleAnalysisShow={handleAnalysisShow}
-                  ID={recordID}
-                  tabKey={recordTabKey}
-                  setTabKey={setRecordTabKey}
-                  dataPanelTabKey={recordDataPanelTabKey}
-                  setDataPanelTabKey={setRecordDataPanelTabKey}
-                  onHide={handleProjectRecordHide}
-                />
+              <Tab.Pane eventKey={OnyxTabKeys.ANALYSES} className="h-100">
+                <Tab.Container activeKey={analysisTabKey}>
+                  <Tab.Content className="h-100">
+                    <Tab.Pane eventKey={AnalysisTabKeys.LIST} className="h-100">
+                      <Results
+                        {...pageProps}
+                        projectFields={analysisFields}
+                        projectDescription={projectDescription}
+                        typeLookups={typeLookups}
+                        fieldDescriptions={analysisDescriptions}
+                        lookupDescriptions={lookupDescriptions}
+                        handleProjectRecordShow={handleProjectRecordShow}
+                        handleAnalysisShow={handleAnalysisShow}
+                        title="Analyses"
+                        searchPath={`projects/${project}/analysis`}
+                      />
+                    </Tab.Pane>
+                    <Tab.Pane
+                      eventKey={AnalysisTabKeys.DETAIL}
+                      className="h-100"
+                      unmountOnExit
+                    >
+                      <Analysis
+                        {...pageProps}
+                        projectFields={analysisFields}
+                        projectDescription={projectDescription}
+                        typeLookups={typeLookups}
+                        fieldDescriptions={analysisDescriptions}
+                        lookupDescriptions={lookupDescriptions}
+                        handleProjectRecordShow={handleProjectRecordShow}
+                        handleAnalysisShow={handleAnalysisShow}
+                        ID={analysisID}
+                        tabKey={analysisDetailTabKey}
+                        setTabKey={setAnalysisDetailTabKey}
+                        dataPanelTabKey={analysisDataPanelTabKey}
+                        setDataPanelTabKey={setAnalysisDataPanelTabKey}
+                        onHide={handleAnalysisHide}
+                      />
+                    </Tab.Pane>
+                  </Tab.Content>
+                </Tab.Container>
               </Tab.Pane>
-              <Tab.Pane eventKey="analyses" className="h-100">
-                <Results
-                  {...pageProps}
-                  projectFields={analysisFields}
-                  projectDescription={projectDescription}
-                  typeLookups={typeLookups}
-                  fieldDescriptions={analysisDescriptions}
-                  lookupDescriptions={lookupDescriptions}
-                  handleProjectRecordShow={handleProjectRecordShow}
-                  handleAnalysisShow={handleAnalysisShow}
-                  title="Analyses"
-                  searchPath={`projects/${project}/analysis`}
-                />
-              </Tab.Pane>
-              <Tab.Pane eventKey="analysis" className="h-100">
-                <Analysis
-                  {...pageProps}
-                  projectFields={analysisFields}
-                  projectDescription={projectDescription}
-                  typeLookups={typeLookups}
-                  fieldDescriptions={analysisDescriptions}
-                  lookupDescriptions={lookupDescriptions}
-                  handleProjectRecordShow={handleProjectRecordShow}
-                  handleAnalysisShow={handleAnalysisShow}
-                  ID={analysisID}
-                  tabKey={analysisTabKey}
-                  setTabKey={setAnalysisTabKey}
-                  dataPanelTabKey={analysisDataPanelTabKey}
-                  setDataPanelTabKey={setAnalysisDataPanelTabKey}
-                  onHide={handleAnalysisHide}
-                />
-              </Tab.Pane>
-              <Tab.Pane eventKey="graphs" className="h-100">
+              <Tab.Pane eventKey={OnyxTabKeys.GRAPHS} className="h-100">
                 <Graphs
                   {...pageProps}
                   projectFields={projectFields}

--- a/lib/components/DataPanel.tsx
+++ b/lib/components/DataPanel.tsx
@@ -96,6 +96,7 @@ function DataPanel(props: DataPanelProps) {
         onSelect={(key) =>
           props.setDataPanelTabKey(key || DataPanelTabKeys.DETAILS)
         }
+        transition={false}
       >
         <ErrorModal
           title="S3 Reports"

--- a/lib/components/DataPanel.tsx
+++ b/lib/components/DataPanel.tsx
@@ -94,7 +94,7 @@ function DataPanel(props: DataPanelProps) {
         id="data-panel-tabs"
         activeKey={props.dataPanelTabKey}
         onSelect={(key) =>
-          props.setDataPanelTabKey(key || DataPanelTabKeys.Details)
+          props.setDataPanelTabKey(key || DataPanelTabKeys.DETAILS)
         }
       >
         <ErrorModal
@@ -129,7 +129,7 @@ function DataPanel(props: DataPanelProps) {
               <hr />
               <Nav variant="pills" className="flex-column">
                 <Nav.Item>
-                  <Nav.Link eventKey={DataPanelTabKeys.Details}>
+                  <Nav.Link eventKey={DataPanelTabKeys.DETAILS}>
                     Details
                   </Nav.Link>
                 </Nav.Item>
@@ -160,7 +160,7 @@ function DataPanel(props: DataPanelProps) {
           </Col>
           <Col xs={9} xl={10} className="h-100">
             <Tab.Content className="h-100">
-              <Tab.Pane eventKey={DataPanelTabKeys.Details} className="h-100">
+              <Tab.Pane eventKey={DataPanelTabKeys.DETAILS} className="h-100">
                 <Details
                   {...props}
                   data={data}

--- a/lib/components/Header.tsx
+++ b/lib/components/Header.tsx
@@ -5,7 +5,6 @@ import Nav from "react-bootstrap/Nav";
 import Navbar from "react-bootstrap/Navbar";
 import NavDropdown from "react-bootstrap/NavDropdown";
 import Stack from "react-bootstrap/Stack";
-import Tab from "react-bootstrap/Tab";
 import { MdDarkMode, MdJoinInner, MdLightMode } from "react-icons/md";
 import { useProfileQuery } from "../api";
 import { PageProps } from "../interfaces";
@@ -18,6 +17,8 @@ interface HeaderProps extends PageProps {
   tabKey: string;
   setTabKey: (k: string) => void;
   handleThemeChange: () => void;
+  handleProjectRecordHide: () => void;
+  handleAnalysisHide: () => void;
 }
 
 function HeaderText({ label, value }: { label: string; value: string }) {
@@ -64,6 +65,22 @@ function Header(props: HeaderProps) {
     };
   }, [data]);
 
+  const handleTabChange = (eventKey: string | null) => {
+    if (
+      props.tabKey === OnyxTabKeys.RECORDS &&
+      eventKey === OnyxTabKeys.RECORDS
+    )
+      props.handleProjectRecordHide();
+
+    if (
+      props.tabKey === OnyxTabKeys.ANALYSES &&
+      eventKey === OnyxTabKeys.ANALYSES
+    )
+      props.handleAnalysisHide();
+
+    props.setTabKey(eventKey || OnyxTabKeys.RECORDS);
+  };
+
   return (
     <Navbar
       style={{
@@ -73,96 +90,95 @@ function Header(props: HeaderProps) {
       variant="dark"
       expand="lg"
       fixed="top"
+      onSelect={handleTabChange}
     >
       <Container fluid>
-        <Tab.Container
-          activeKey={props.tabKey}
-          onSelect={(k) => props.setTabKey(k || OnyxTabKeys.RECORDS)}
+        <Navbar.Brand
+          title="Onyx | API for Pathogen Metadata"
+          onClick={() => {
+            props.setTabKey(OnyxTabKeys.RECORDS);
+            props.handleProjectRecordHide();
+          }}
+          style={{ cursor: "pointer" }}
         >
-          <Navbar.Brand
-            title="Onyx | API for Pathogen Metadata"
-            onClick={() => props.setTabKey(OnyxTabKeys.RECORDS)}
-            style={{ cursor: "pointer" }}
-          >
-            <MdJoinInner color="var(--bs-pink)" /> Onyx
-          </Navbar.Brand>
-          <Navbar.Toggle aria-controls="responsive-navbar-nav" />
-          <Navbar.Collapse id="responsive-navbar-nav">
-            <Nav className="me-auto">
-              <NavDropdown
-                title={<HeaderText label="Project" value={props.projectName} />}
-                style={{ color: "white" }}
-              >
-                {props.projectList.map((p) => (
-                  <NavDropdown.Item
-                    key={p}
-                    onClick={() => props.handleProjectChange(p)}
-                  >
-                    {p}
-                  </NavDropdown.Item>
-                ))}
-              </NavDropdown>
-              <Nav variant="underline">
-                <Stack direction="horizontal" gap={3}>
-                  <Nav.Link eventKey={OnyxTabKeys.USER} className="fw-normal">
-                    <HeaderText
-                      label="User"
-                      value={
-                        isFetching
-                          ? "Loading..."
-                          : error
-                          ? "Failed to load"
-                          : profile.username
-                      }
-                    />
-                  </Nav.Link>
-                  <Nav.Link eventKey={OnyxTabKeys.SITE} className="fw-normal">
-                    <HeaderText
-                      label="Site"
-                      value={
-                        isFetching
-                          ? "Loading..."
-                          : error
-                          ? "Failed to load"
-                          : profile.site
-                      }
-                    />
-                  </Nav.Link>
-                  <Nav.Link disabled className="fw-normal ">
-                    <HeaderVersion label="Version" version={props.extVersion} />
-                  </Nav.Link>
-                </Stack>
-              </Nav>
-            </Nav>
+          <MdJoinInner color="var(--bs-pink)" size={30} /> Onyx
+        </Navbar.Brand>
+        <Navbar.Toggle aria-controls="responsive-navbar-nav" />
+        <Navbar.Collapse id="responsive-navbar-nav">
+          <Nav className="me-auto" activeKey={props.tabKey}>
+            <NavDropdown
+              title={<HeaderText label="Project" value={props.projectName} />}
+              style={{ color: "white" }}
+            >
+              {props.projectList.map((p) => (
+                <NavDropdown.Item
+                  key={p}
+                  onClick={() => props.handleProjectChange(p)}
+                >
+                  {p}
+                </NavDropdown.Item>
+              ))}
+            </NavDropdown>
             <Nav variant="underline">
               <Stack direction="horizontal" gap={3}>
-                <Nav.Link eventKey={OnyxTabKeys.RECORDS} className="fw-normal">
-                  Records
+                <Nav.Link eventKey={OnyxTabKeys.USER} className="fw-normal">
+                  <HeaderText
+                    label="User"
+                    value={
+                      isFetching
+                        ? "Loading..."
+                        : error
+                        ? "Failed to load"
+                        : profile.username
+                    }
+                  />
                 </Nav.Link>
-                <Nav.Link eventKey={OnyxTabKeys.ANALYSES} className="fw-normal">
-                  Analyses
+                <Nav.Link eventKey={OnyxTabKeys.SITE} className="fw-normal">
+                  <HeaderText
+                    label="Site"
+                    value={
+                      isFetching
+                        ? "Loading..."
+                        : error
+                        ? "Failed to load"
+                        : profile.site
+                    }
+                  />
                 </Nav.Link>
-                <Nav.Link eventKey={OnyxTabKeys.GRAPHS} className="fw-normal">
-                  Graphs
+                <Nav.Link disabled className="fw-normal ">
+                  <HeaderVersion label="Version" version={props.extVersion} />
                 </Nav.Link>
-                <Form.Check
-                  type="switch"
-                  id="theme-switch"
-                  label={
-                    <span className="text-light">
-                      {props.darkMode ? <MdDarkMode /> : <MdLightMode />}{" "}
-                    </span>
-                  }
-                  title={`Switch to ${
-                    props.darkMode ? "light mode" : "dark mode"
-                  }`}
-                  checked={props.darkMode}
-                  onChange={props.handleThemeChange}
-                />
               </Stack>
             </Nav>
-          </Navbar.Collapse>
-        </Tab.Container>
+          </Nav>
+          <Nav variant="underline" activeKey={props.tabKey}>
+            <Stack direction="horizontal" gap={3}>
+              <Nav.Link eventKey={OnyxTabKeys.RECORDS} className="fw-normal">
+                Records
+              </Nav.Link>
+              <Nav.Link eventKey={OnyxTabKeys.ANALYSES} className="fw-normal">
+                Analyses
+              </Nav.Link>
+              <Nav.Link eventKey={OnyxTabKeys.GRAPHS} className="fw-normal">
+                Graphs
+              </Nav.Link>
+              <Form.Check
+                type="switch"
+                id="theme-switch"
+                label={
+                  <span className="text-light">
+                    {props.darkMode ? <MdDarkMode /> : <MdLightMode />}{" "}
+                  </span>
+                }
+                title={`Switch to ${
+                  props.darkMode ? "light mode" : "dark mode"
+                }`}
+                checked={props.darkMode}
+                onChange={props.handleThemeChange}
+              />
+            </Stack>
+          </Nav>
+        </Navbar.Collapse>
       </Container>
     </Navbar>
   );

--- a/lib/components/Header.tsx
+++ b/lib/components/Header.tsx
@@ -9,6 +9,7 @@ import Tab from "react-bootstrap/Tab";
 import { MdDarkMode, MdJoinInner, MdLightMode } from "react-icons/md";
 import { useProfileQuery } from "../api";
 import { PageProps } from "../interfaces";
+import { OnyxTabKeys } from "../types";
 
 interface HeaderProps extends PageProps {
   projectName: string;
@@ -17,10 +18,6 @@ interface HeaderProps extends PageProps {
   tabKey: string;
   setTabKey: (k: string) => void;
   handleThemeChange: () => void;
-  recordID: string;
-  handleProjectRecordHide: () => void;
-  analysisID: string;
-  handleAnalysisHide: () => void;
 }
 
 function HeaderText({ label, value }: { label: string; value: string }) {
@@ -67,20 +64,6 @@ function Header(props: HeaderProps) {
     };
   }, [data]);
 
-  const handleTabChange = (eventKey: string | null) => {
-    if (eventKey === "records" && props.recordID) {
-      if (props.tabKey === "record") {
-        props.handleProjectRecordHide();
-      } else {
-        props.setTabKey("record");
-      }
-    } else if (eventKey === "analyses" && props.analysisID) {
-      if (props.tabKey === "analysis") {
-        props.handleAnalysisHide();
-      } else props.setTabKey("analysis");
-    } else props.setTabKey(eventKey || "records");
-  };
-
   return (
     <Navbar
       style={{
@@ -92,10 +75,13 @@ function Header(props: HeaderProps) {
       fixed="top"
     >
       <Container fluid>
-        <Tab.Container activeKey={props.tabKey} onSelect={handleTabChange}>
+        <Tab.Container
+          activeKey={props.tabKey}
+          onSelect={(k) => props.setTabKey(k || OnyxTabKeys.RECORDS)}
+        >
           <Navbar.Brand
             title="Onyx | API for Pathogen Metadata"
-            onClick={() => handleTabChange("records")}
+            onClick={() => props.setTabKey(OnyxTabKeys.RECORDS)}
             style={{ cursor: "pointer" }}
           >
             <MdJoinInner color="var(--bs-pink)" /> Onyx
@@ -118,7 +104,7 @@ function Header(props: HeaderProps) {
               </NavDropdown>
               <Nav variant="underline">
                 <Stack direction="horizontal" gap={3}>
-                  <Nav.Link eventKey="user" className="fw-normal">
+                  <Nav.Link eventKey={OnyxTabKeys.USER} className="fw-normal">
                     <HeaderText
                       label="User"
                       value={
@@ -130,7 +116,7 @@ function Header(props: HeaderProps) {
                       }
                     />
                   </Nav.Link>
-                  <Nav.Link eventKey="site" className="fw-normal">
+                  <Nav.Link eventKey={OnyxTabKeys.SITE} className="fw-normal">
                     <HeaderText
                       label="Site"
                       value={
@@ -150,25 +136,13 @@ function Header(props: HeaderProps) {
             </Nav>
             <Nav variant="underline">
               <Stack direction="horizontal" gap={3}>
-                <Nav.Link
-                  eventKey="records"
-                  className="fw-normal"
-                  active={
-                    props.tabKey === "records" || props.tabKey === "record"
-                  }
-                >
+                <Nav.Link eventKey={OnyxTabKeys.RECORDS} className="fw-normal">
                   Records
                 </Nav.Link>
-                <Nav.Link
-                  eventKey="analyses"
-                  className="fw-normal"
-                  active={
-                    props.tabKey === "analyses" || props.tabKey === "analysis"
-                  }
-                >
+                <Nav.Link eventKey={OnyxTabKeys.ANALYSES} className="fw-normal">
                   Analyses
                 </Nav.Link>
-                <Nav.Link eventKey="graphs" className="fw-normal">
+                <Nav.Link eventKey={OnyxTabKeys.GRAPHS} className="fw-normal">
                   Graphs
                 </Nav.Link>
                 <Form.Check

--- a/lib/pages/Analysis.tsx
+++ b/lib/pages/Analysis.tsx
@@ -173,6 +173,7 @@ function Analysis(props: IDProps) {
               props.setTabKey(key || AnalysisDetailTabKeys.DATA)
             }
             mountOnEnter
+            transition={false}
           >
             <Nav variant="tabs">
               <Nav.Item>

--- a/lib/pages/Analysis.tsx
+++ b/lib/pages/Analysis.tsx
@@ -25,7 +25,7 @@ import History from "../components/History";
 import QueryHandler from "../components/QueryHandler";
 import Table from "../components/Table";
 import { IDProps } from "../interfaces";
-import { AnalysisTabKeys, ErrorResponse, ListResponse } from "../types";
+import { AnalysisDetailTabKeys, ErrorResponse, ListResponse } from "../types";
 import { s3BucketsMessage } from "../utils/messages";
 
 interface RelatedAnalysesProps extends IDProps {
@@ -169,25 +169,32 @@ function Analysis(props: IDProps) {
         <Card.Body className="pt-2 overflow-y-auto">
           <Tab.Container
             activeKey={props.tabKey}
-            onSelect={(key) => props.setTabKey(key || AnalysisTabKeys.Data)}
+            onSelect={(key) =>
+              props.setTabKey(key || AnalysisDetailTabKeys.DATA)
+            }
+            mountOnEnter
           >
             <Nav variant="tabs">
               <Nav.Item>
-                <Nav.Link eventKey={AnalysisTabKeys.Data}>Data</Nav.Link>
+                <Nav.Link eventKey={AnalysisDetailTabKeys.DATA}>Data</Nav.Link>
               </Nav.Item>
               <Nav.Item>
-                <Nav.Link eventKey={AnalysisTabKeys.History}>History</Nav.Link>
+                <Nav.Link eventKey={AnalysisDetailTabKeys.HISTORY}>
+                  History
+                </Nav.Link>
               </Nav.Item>
               <Nav.Item>
-                <Nav.Link eventKey={AnalysisTabKeys.Records}>Records</Nav.Link>
+                <Nav.Link eventKey={AnalysisDetailTabKeys.RECORDS}>
+                  Records
+                </Nav.Link>
               </Nav.Item>
               <Nav.Item>
-                <Nav.Link eventKey={AnalysisTabKeys.Upstream}>
+                <Nav.Link eventKey={AnalysisDetailTabKeys.UPSTREAM}>
                   Upstream
                 </Nav.Link>
               </Nav.Item>
               <Nav.Item>
-                <Nav.Link eventKey={AnalysisTabKeys.Downstream}>
+                <Nav.Link eventKey={AnalysisDetailTabKeys.DOWNSTREAM}>
                   Downstream
                 </Nav.Link>
               </Nav.Item>
@@ -196,7 +203,7 @@ function Analysis(props: IDProps) {
               className="p-3"
               style={{ height: "calc(100% - 60px)" }}
             >
-              <Tab.Pane eventKey={AnalysisTabKeys.Data} className="h-100">
+              <Tab.Pane eventKey={AnalysisDetailTabKeys.DATA} className="h-100">
                 <DataPanel
                   {...props}
                   queryHook={useAnalysisQuery}
@@ -210,7 +217,10 @@ function Analysis(props: IDProps) {
                   }
                 />
               </Tab.Pane>
-              <Tab.Pane eventKey={AnalysisTabKeys.History} className="h-100">
+              <Tab.Pane
+                eventKey={AnalysisDetailTabKeys.HISTORY}
+                className="h-100"
+              >
                 <History
                   {...props}
                   name="analysis"
@@ -218,13 +228,22 @@ function Analysis(props: IDProps) {
                   ID={props.ID}
                 />
               </Tab.Pane>
-              <Tab.Pane eventKey={AnalysisTabKeys.Records} className="h-100">
+              <Tab.Pane
+                eventKey={AnalysisDetailTabKeys.RECORDS}
+                className="h-100"
+              >
                 <Records {...props} />
               </Tab.Pane>
-              <Tab.Pane eventKey={AnalysisTabKeys.Upstream} className="h-100">
+              <Tab.Pane
+                eventKey={AnalysisDetailTabKeys.UPSTREAM}
+                className="h-100"
+              >
                 <Upstream {...props} />
               </Tab.Pane>
-              <Tab.Pane eventKey={AnalysisTabKeys.Downstream} className="h-100">
+              <Tab.Pane
+                eventKey={AnalysisDetailTabKeys.DOWNSTREAM}
+                className="h-100"
+              >
                 <Downstream {...props} />
               </Tab.Pane>
             </Tab.Content>

--- a/lib/pages/Graphs.tsx
+++ b/lib/pages/Graphs.tsx
@@ -34,7 +34,12 @@ import {
 } from "../components/Graphs";
 import PageTitle from "../components/PageTitle";
 import { DataProps } from "../interfaces";
-import { FilterConfig, GraphConfig, GraphType } from "../types";
+import {
+  FilterConfig,
+  GraphConfig,
+  GraphType,
+  GraphPanelTabKeys,
+} from "../types";
 import { generateKey } from "../utils/functions";
 import RemoveAllModal from "../components/RemoveAllModal";
 
@@ -154,12 +159,12 @@ function GraphPanelOptions(props: GraphPanelProps) {
 
   return (
     <Tabs
-      defaultActiveKey="graph"
+      defaultActiveKey={GraphPanelTabKeys.GRAPH}
       id="uncontrolled-tab-example"
       className="mb-3"
       justify
     >
-      <Tab eventKey="graph" title="Graph">
+      <Tab eventKey={GraphPanelTabKeys.GRAPH} title="Graph">
         <Form>
           <Form.Group className="mb-3">
             <Form.Label>Graph Type</Form.Label>
@@ -210,7 +215,7 @@ function GraphPanelOptions(props: GraphPanelProps) {
           )}
         </Form>
       </Tab>
-      <Tab eventKey="filters" title="Filters">
+      <Tab eventKey={GraphPanelTabKeys.FILTERS} title="Filters">
         {props.graphConfig.type && (
           <FilterPanel
             {...props}
@@ -221,7 +226,7 @@ function GraphPanelOptions(props: GraphPanelProps) {
           />
         )}
       </Tab>
-      <Tab eventKey="display" title="Display">
+      <Tab eventKey={GraphPanelTabKeys.DISPLAY} title="Display">
         {(props.graphConfig.type === "line" ||
           props.graphConfig.type === "bar") && (
           <Form.Group className="mb-3">

--- a/lib/pages/Graphs.tsx
+++ b/lib/pages/Graphs.tsx
@@ -163,6 +163,7 @@ function GraphPanelOptions(props: GraphPanelProps) {
       id="uncontrolled-tab-example"
       className="mb-3"
       justify
+      transition={false}
     >
       <Tab eventKey={GraphPanelTabKeys.GRAPH} title="Graph">
         <Form>

--- a/lib/pages/ProjectRecord.tsx
+++ b/lib/pages/ProjectRecord.tsx
@@ -70,6 +70,7 @@ function ProjectRecord(props: IDProps) {
             activeKey={props.tabKey}
             onSelect={(key) => props.setTabKey(key || RecordDetailTabKeys.DATA)}
             mountOnEnter
+            transition={false}
           >
             <Nav variant="tabs">
               <Nav.Item>

--- a/lib/pages/ProjectRecord.tsx
+++ b/lib/pages/ProjectRecord.tsx
@@ -14,7 +14,7 @@ import History from "../components/History";
 import QueryHandler from "../components/QueryHandler";
 import Table from "../components/Table";
 import { IDProps } from "../interfaces";
-import { RecordTabKeys } from "../types";
+import { RecordDetailTabKeys } from "../types";
 
 function Analyses(props: IDProps) {
   const { isFetching, error, data } = useRecordAnalysesQuery(props);
@@ -68,24 +68,29 @@ function ProjectRecord(props: IDProps) {
         <Card.Body className="pt-2 overflow-y-auto">
           <Tab.Container
             activeKey={props.tabKey}
-            onSelect={(key) => props.setTabKey(key || RecordTabKeys.Data)}
+            onSelect={(key) => props.setTabKey(key || RecordDetailTabKeys.DATA)}
+            mountOnEnter
           >
             <Nav variant="tabs">
               <Nav.Item>
-                <Nav.Link eventKey={RecordTabKeys.Data}>Data</Nav.Link>
+                <Nav.Link eventKey={RecordDetailTabKeys.DATA}>Data</Nav.Link>
               </Nav.Item>
               <Nav.Item>
-                <Nav.Link eventKey={RecordTabKeys.History}>History</Nav.Link>
+                <Nav.Link eventKey={RecordDetailTabKeys.HISTORY}>
+                  History
+                </Nav.Link>
               </Nav.Item>
               <Nav.Item>
-                <Nav.Link eventKey={RecordTabKeys.Analyses}>Analyses</Nav.Link>
+                <Nav.Link eventKey={RecordDetailTabKeys.ANALYSES}>
+                  Analyses
+                </Nav.Link>
               </Nav.Item>
             </Nav>
             <Tab.Content
               className="p-3"
               style={{ height: "calc(100% - 60px)" }}
             >
-              <Tab.Pane eventKey={RecordTabKeys.Data} className="h-100">
+              <Tab.Pane eventKey={RecordDetailTabKeys.DATA} className="h-100">
                 <DataPanel
                   {...props}
                   queryHook={useRecordQuery}
@@ -99,7 +104,10 @@ function ProjectRecord(props: IDProps) {
                   }
                 />
               </Tab.Pane>
-              <Tab.Pane eventKey={RecordTabKeys.History} className="h-100">
+              <Tab.Pane
+                eventKey={RecordDetailTabKeys.HISTORY}
+                className="h-100"
+              >
                 <History
                   {...props}
                   name="record"
@@ -107,7 +115,10 @@ function ProjectRecord(props: IDProps) {
                   ID={props.ID}
                 />
               </Tab.Pane>
-              <Tab.Pane eventKey={RecordTabKeys.Analyses} className="h-100">
+              <Tab.Pane
+                eventKey={RecordDetailTabKeys.ANALYSES}
+                className="h-100"
+              >
                 <Analyses {...props} />
               </Tab.Pane>
             </Tab.Content>

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,19 +1,43 @@
+export enum OnyxTabKeys {
+  USER = "user-tab",
+  SITE = "site-tab",
+  RECORDS = "records-tab",
+  ANALYSES = "analyses-tab",
+  GRAPHS = "graphs-tab",
+}
+
 export enum RecordTabKeys {
-  Data = "record-data-tab",
-  History = "record-history-tab",
-  Analyses = "record-analyses-tab",
+  LIST = "record-list-tab",
+  DETAIL = "record-detail-tab",
 }
 
 export enum AnalysisTabKeys {
-  Data = "analysis-data-tab",
-  History = "analysis-history-tab",
-  Records = "analysis-records-tab",
-  Upstream = "analysis-upstream-tab",
-  Downstream = "analysis-downstream-tab",
+  LIST = "analysis-list-tab",
+  DETAIL = "analysis-detail-tab",
+}
+
+export enum RecordDetailTabKeys {
+  DATA = "record-detail-data-tab",
+  HISTORY = "record-detail-history-tab",
+  ANALYSES = "record-detail-analyses-tab",
+}
+
+export enum AnalysisDetailTabKeys {
+  DATA = "analysis-detail-data-tab",
+  HISTORY = "analysis-detail-history-tab",
+  RECORDS = "analysis-detail-records-tab",
+  UPSTREAM = "analysis-detail-upstream-tab",
+  DOWNSTREAM = "analysis-detail-downstream-tab",
 }
 
 export enum DataPanelTabKeys {
-  Details = "data-panel-details",
+  DETAILS = "data-panel-details",
+}
+
+export enum GraphPanelTabKeys {
+  GRAPH = "graph-panel-graph",
+  FILTERS = "graph-panel-filters",
+  DISPLAY = "graph-panel-display",
 }
 
 export enum ExportStatus {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "climb-onyx-gui",
-  "version": "0.14.3",
+  "version": "0.14.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "climb-onyx-gui",
-      "version": "0.14.3",
+      "version": "0.14.4",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@ag-grid-community/client-side-row-model": "^32.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "climb-onyx-gui",
-  "version": "0.14.3",
+  "version": "0.14.4",
   "description": "Onyx Graphical User Interface",
   "keywords": [
     "gui",


### PR DESCRIPTION
- Restructured tabs to enable better lazy loading of record/analysis details in #88
- Added more tab enums in #88  
- Improved header code structure in #89
- Improved logo size in #89 
- Removed janky tab transitions in #89  