### PR TITLE
Project Tabs

### DIFF
--- a/lib/Onyx.tsx
+++ b/lib/Onyx.tsx
@@ -2,6 +2,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import Container from "react-bootstrap/Container";
 import Tab from "react-bootstrap/Tab";
+import { MdJoinInner } from "react-icons/md";
 import {
   useAnalysisFieldsQuery,
   useLookupsQuery,
@@ -9,9 +10,10 @@ import {
   useProjectPermissionsQuery,
   useTypesQuery,
 } from "./api";
+import Fade from "react-bootstrap/Fade";
 import { useFieldsInfo } from "./api/hooks";
 import Header from "./components/Header";
-import { OnyxProps } from "./interfaces";
+import { OnyxProps, PageProps } from "./interfaces";
 import Analysis from "./pages/Analysis";
 import Graphs from "./pages/Graphs";
 import ProjectRecord from "./pages/ProjectRecord";
@@ -24,22 +26,189 @@ import {
   DataPanelTabKeys,
   LookupObject,
   OnyxTabKeys,
+  Project,
   ProjectPermissionType,
   RecordTabKeys,
   RecordDetailTabKeys,
+  Theme,
   TypeObject,
 } from "./types";
+import { useDelayedValue } from "./utils/hooks";
 
 import "@fontsource/ibm-plex-sans";
 import "./Onyx.css";
 import "./bootstrap.css";
+import PageTitle from "./components/PageTitle";
+
+interface ProjectPageProps extends PageProps {
+  typeLookups: Map<string, string[]>;
+  lookupDescriptions: Map<string, string>;
+  tabKey: string;
+  recordTabKey: string;
+  analysisTabKey: string;
+  recordID: string;
+  analysisID: string;
+  handleProjectRecordShow: (recordID: string) => void;
+  handleAnalysisShow: (analysisID: string) => void;
+  handleProjectRecordHide: () => void;
+  handleAnalysisHide: () => void;
+  recordDetailTabKey: string;
+  setRecordDetailTabKey: (key: string) => void;
+  recordDataPanelTabKey: string;
+  setRecordDataPanelTabKey: (key: string) => void;
+  analysisDetailTabKey: string;
+  setAnalysisDetailTabKey: (key: string) => void;
+  analysisDataPanelTabKey: string;
+  setAnalysisDataPanelTabKey: (key: string) => void;
+}
+
+function ProjectPage(props: ProjectPageProps) {
+  // Get project information
+  const { data: projectFieldsResponse } = useProjectFieldsQuery(props);
+  const {
+    description: projectDescription,
+    fields: projectFields,
+    descriptions: fieldDescriptions,
+  } = useFieldsInfo(projectFieldsResponse);
+
+  // Get project analyses information
+  const { data: analysisFieldsResponse } = useAnalysisFieldsQuery(props);
+  const { fields: analysisFields, descriptions: analysisDescriptions } =
+    useFieldsInfo(analysisFieldsResponse);
+
+  return (
+    <Tab.Container activeKey={props.tabKey} mountOnEnter transition={false}>
+      <Tab.Content className="h-100">
+        <Tab.Pane eventKey={OnyxTabKeys.USER} className="h-100">
+          <User {...props} />
+        </Tab.Pane>
+        <Tab.Pane eventKey={OnyxTabKeys.SITE} className="h-100">
+          <Site {...props} />
+        </Tab.Pane>
+        <Tab.Pane eventKey={OnyxTabKeys.RECORDS} className="h-100">
+          <Tab.Container activeKey={props.recordTabKey} transition={false}>
+            <Tab.Content className="h-100">
+              <Tab.Pane eventKey={RecordTabKeys.LIST} className="h-100">
+                <Results
+                  {...props}
+                  projectFields={projectFields}
+                  projectDescription={projectDescription}
+                  fieldDescriptions={fieldDescriptions}
+                  title="Records"
+                  searchPath={`projects/${props.project}`}
+                />
+              </Tab.Pane>
+              <Tab.Pane
+                eventKey={RecordTabKeys.DETAIL}
+                className="h-100"
+                unmountOnExit
+              >
+                <ProjectRecord
+                  {...props}
+                  projectFields={projectFields}
+                  projectDescription={projectDescription}
+                  fieldDescriptions={fieldDescriptions}
+                  ID={props.recordID}
+                  tabKey={props.recordDetailTabKey}
+                  setTabKey={props.setRecordDetailTabKey}
+                  dataPanelTabKey={props.recordDataPanelTabKey}
+                  setDataPanelTabKey={props.setRecordDataPanelTabKey}
+                  onHide={props.handleProjectRecordHide}
+                />
+              </Tab.Pane>
+            </Tab.Content>
+          </Tab.Container>
+        </Tab.Pane>
+        <Tab.Pane eventKey={OnyxTabKeys.ANALYSES} className="h-100">
+          <Tab.Container activeKey={props.analysisTabKey} transition={false}>
+            <Tab.Content className="h-100">
+              <Tab.Pane eventKey={AnalysisTabKeys.LIST} className="h-100">
+                <Results
+                  {...props}
+                  projectFields={analysisFields}
+                  projectDescription={projectDescription}
+                  fieldDescriptions={analysisDescriptions}
+                  title="Analyses"
+                  searchPath={`projects/${props.project}/analysis`}
+                />
+              </Tab.Pane>
+              <Tab.Pane
+                eventKey={AnalysisTabKeys.DETAIL}
+                className="h-100"
+                unmountOnExit
+              >
+                <Analysis
+                  {...props}
+                  projectFields={analysisFields}
+                  projectDescription={projectDescription}
+                  fieldDescriptions={analysisDescriptions}
+                  ID={props.analysisID}
+                  tabKey={props.analysisDetailTabKey}
+                  setTabKey={props.setAnalysisDetailTabKey}
+                  dataPanelTabKey={props.analysisDataPanelTabKey}
+                  setDataPanelTabKey={props.setAnalysisDataPanelTabKey}
+                  onHide={props.handleAnalysisHide}
+                />
+              </Tab.Pane>
+            </Tab.Content>
+          </Tab.Container>
+        </Tab.Pane>
+        <Tab.Pane eventKey={OnyxTabKeys.GRAPHS} className="h-100">
+          <Graphs
+            {...props}
+            projectFields={projectFields}
+            projectDescription={projectDescription}
+            fieldDescriptions={fieldDescriptions}
+          />
+        </Tab.Pane>
+      </Tab.Content>
+    </Tab.Container>
+  );
+}
+
+function LandingPage() {
+  const showPage = useDelayedValue(1000);
+
+  return showPage ? (
+    <div className="h-100 d-flex justify-content-center align-items-center">
+      <Fade in={showPage} appear>
+        <h1 className="text-center">
+          <MdJoinInner color="var(--bs-pink)" size={100} />{" "}
+          <PageTitle title="Onyx" description="API for Pathogen Metadata" />
+        </h1>
+      </Fade>
+    </div>
+  ) : (
+    <></>
+  );
+}
 
 function App(props: OnyxProps) {
-  // Global app state
+  // Theme state
   const [darkMode, setDarkMode] = useState(
-    localStorage.getItem("onyx-theme") === "dark"
+    localStorage.getItem("onyx-theme") === Theme.DARK
   );
-  const [project, setProject] = useState("");
+
+  // Set the theme based on darkMode
+  useEffect(() => {
+    const htmlElement = document.querySelector("html");
+    htmlElement?.setAttribute(
+      "data-bs-theme",
+      darkMode ? Theme.DARK : Theme.LIGHT
+    );
+  }, [darkMode]);
+
+  const handleThemeChange = () => {
+    const darkModeChange = !darkMode;
+    setDarkMode(darkModeChange);
+    localStorage.setItem(
+      "onyx-theme",
+      darkModeChange ? Theme.DARK : Theme.LIGHT
+    );
+  };
+
+  // Project state
+  const [project, setProject] = useState<Project>();
   const [tabKey, setTabKey] = useState<string>(OnyxTabKeys.RECORDS);
 
   // Record tab state
@@ -63,20 +232,8 @@ function App(props: OnyxProps) {
   const [analysisDataPanelTabKey, setAnalysisDataPanelTabKey] =
     useState<string>(DataPanelTabKeys.DETAILS);
 
-  // Set the theme based on darkMode state
-  useEffect(() => {
-    const htmlElement = document.querySelector("html");
-    htmlElement?.setAttribute("data-bs-theme", darkMode ? "dark" : "light");
-  }, [darkMode]);
-
-  const handleThemeChange = () => {
-    const darkModeChange = !darkMode;
-    setDarkMode(darkModeChange);
-    localStorage.setItem("onyx-theme", darkModeChange ? "dark" : "light");
-  };
-
   // Clear parameters when project changes
-  const handleProjectChange = (project: string) => {
+  const handleProjectChange = (project: Project) => {
     setTabKey(OnyxTabKeys.RECORDS);
     setRecordTabKey(RecordTabKeys.LIST);
     setAnalysisTabKey(AnalysisTabKeys.LIST);
@@ -85,27 +242,11 @@ function App(props: OnyxProps) {
     setProject(project);
   };
 
-  const pageProps = useMemo(
-    () => ({
-      ...props,
-      project,
-      darkMode,
-    }),
-    [props, project, darkMode]
-  );
-
   // Query for types, lookups and project permissions
   const { data: typesResponse } = useTypesQuery(props);
   const { data: lookupsResponse } = useLookupsQuery(props);
   const { data: projectPermissionsResponse } =
     useProjectPermissionsQuery(props);
-  const {
-    isFetching: projectFieldsPending,
-    error: projectFieldsError,
-    data: projectFieldsResponse,
-  } = useProjectFieldsQuery(pageProps);
-
-  const { data: analysisFieldsResponse } = useAnalysisFieldsQuery(pageProps);
 
   // Get a map of types to their lookups
   const typeLookups = useMemo(() => {
@@ -130,10 +271,11 @@ function App(props: OnyxProps) {
   const projects = useMemo(() => {
     if (projectPermissionsResponse?.status !== "success") return [];
     return projectPermissionsResponse.data
-      .map(
-        (projectPermission: ProjectPermissionType) => projectPermission.project
-      )
-      .sort() as string[];
+      .map((projectPermission: ProjectPermissionType) => ({
+        code: projectPermission.project,
+        name: projectPermission.name,
+      }))
+      .sort() as Project[];
   }, [projectPermissionsResponse]);
 
   // Set the first project as the default
@@ -142,18 +284,6 @@ function App(props: OnyxProps) {
       setProject(projects[0]);
     }
   }, [project, projects]);
-
-  // Get project information
-  const {
-    name: projectName,
-    description: projectDescription,
-    fields: projectFields,
-    descriptions: fieldDescriptions,
-  } = useFieldsInfo(projectFieldsResponse);
-
-  // Get project analyses information
-  const { fields: analysisFields, descriptions: analysisDescriptions } =
-    useFieldsInfo(analysisFieldsResponse);
 
   // https://react.dev/reference/react/useCallback#skipping-re-rendering-of-components
   // Usage of useCallback here prevents excessive re-rendering of the ResultsPanel
@@ -186,15 +316,9 @@ function App(props: OnyxProps) {
     <div className="Onyx h-100">
       <Header
         {...props}
-        project={project}
-        projectName={
-          projectFieldsPending
-            ? "Loading..."
-            : projectFieldsError
-            ? "Failed to load"
-            : projectName
-        }
-        projectList={projects}
+        project={project?.code || ""}
+        projectObj={project}
+        projectObjs={projects}
         handleProjectChange={handleProjectChange}
         tabKey={tabKey}
         setTabKey={setTabKey}
@@ -205,163 +329,47 @@ function App(props: OnyxProps) {
       />
       <div className="h-100" style={{ paddingTop: "60px" }}>
         <Container fluid className="h-100 p-2">
-          <Tab.Container
-            activeKey={project}
-            mountOnEnter
-            unmountOnExit
-            transition={false}
-          >
-            <Tab.Content className="h-100">
-              {projects.map((project) => (
-                <Tab.Pane key={project} eventKey={project} className="h-100">
-                  <Tab.Container
-                    activeKey={tabKey}
-                    mountOnEnter
-                    transition={false}
-                  >
-                    <Tab.Content className="h-100">
-                      <Tab.Pane eventKey={OnyxTabKeys.USER} className="h-100">
-                        <User
-                          {...props}
-                          project={project}
-                          darkMode={darkMode}
-                        />
-                      </Tab.Pane>
-                      <Tab.Pane eventKey={OnyxTabKeys.SITE} className="h-100">
-                        <Site
-                          {...props}
-                          project={project}
-                          darkMode={darkMode}
-                        />
-                      </Tab.Pane>
-                      <Tab.Pane
-                        eventKey={OnyxTabKeys.RECORDS}
-                        className="h-100"
-                      >
-                        <Tab.Container
-                          activeKey={recordTabKey}
-                          transition={false}
-                        >
-                          <Tab.Content className="h-100">
-                            <Tab.Pane
-                              eventKey={RecordTabKeys.LIST}
-                              className="h-100"
-                            >
-                              <Results
-                                {...pageProps}
-                                projectFields={projectFields}
-                                projectDescription={projectDescription}
-                                typeLookups={typeLookups}
-                                fieldDescriptions={fieldDescriptions}
-                                lookupDescriptions={lookupDescriptions}
-                                handleProjectRecordShow={
-                                  handleProjectRecordShow
-                                }
-                                handleAnalysisShow={handleAnalysisShow}
-                                title="Records"
-                                searchPath={`projects/${project}`}
-                              />
-                            </Tab.Pane>
-                            <Tab.Pane
-                              eventKey={RecordTabKeys.DETAIL}
-                              className="h-100"
-                              unmountOnExit
-                            >
-                              <ProjectRecord
-                                {...pageProps}
-                                projectFields={projectFields}
-                                projectDescription={projectDescription}
-                                typeLookups={typeLookups}
-                                fieldDescriptions={fieldDescriptions}
-                                lookupDescriptions={lookupDescriptions}
-                                handleProjectRecordShow={
-                                  handleProjectRecordShow
-                                }
-                                handleAnalysisShow={handleAnalysisShow}
-                                ID={recordID}
-                                tabKey={recordDetailTabKey}
-                                setTabKey={setRecordDetailTabKey}
-                                dataPanelTabKey={recordDataPanelTabKey}
-                                setDataPanelTabKey={setRecordDataPanelTabKey}
-                                onHide={handleProjectRecordHide}
-                              />
-                            </Tab.Pane>
-                          </Tab.Content>
-                        </Tab.Container>
-                      </Tab.Pane>
-                      <Tab.Pane
-                        eventKey={OnyxTabKeys.ANALYSES}
-                        className="h-100"
-                      >
-                        <Tab.Container
-                          activeKey={analysisTabKey}
-                          transition={false}
-                        >
-                          <Tab.Content className="h-100">
-                            <Tab.Pane
-                              eventKey={AnalysisTabKeys.LIST}
-                              className="h-100"
-                            >
-                              <Results
-                                {...pageProps}
-                                projectFields={analysisFields}
-                                projectDescription={projectDescription}
-                                typeLookups={typeLookups}
-                                fieldDescriptions={analysisDescriptions}
-                                lookupDescriptions={lookupDescriptions}
-                                handleProjectRecordShow={
-                                  handleProjectRecordShow
-                                }
-                                handleAnalysisShow={handleAnalysisShow}
-                                title="Analyses"
-                                searchPath={`projects/${project}/analysis`}
-                              />
-                            </Tab.Pane>
-                            <Tab.Pane
-                              eventKey={AnalysisTabKeys.DETAIL}
-                              className="h-100"
-                              unmountOnExit
-                            >
-                              <Analysis
-                                {...pageProps}
-                                projectFields={analysisFields}
-                                projectDescription={projectDescription}
-                                typeLookups={typeLookups}
-                                fieldDescriptions={analysisDescriptions}
-                                lookupDescriptions={lookupDescriptions}
-                                handleProjectRecordShow={
-                                  handleProjectRecordShow
-                                }
-                                handleAnalysisShow={handleAnalysisShow}
-                                ID={analysisID}
-                                tabKey={analysisDetailTabKey}
-                                setTabKey={setAnalysisDetailTabKey}
-                                dataPanelTabKey={analysisDataPanelTabKey}
-                                setDataPanelTabKey={setAnalysisDataPanelTabKey}
-                                onHide={handleAnalysisHide}
-                              />
-                            </Tab.Pane>
-                          </Tab.Content>
-                        </Tab.Container>
-                      </Tab.Pane>
-                      <Tab.Pane eventKey={OnyxTabKeys.GRAPHS} className="h-100">
-                        <Graphs
-                          {...pageProps}
-                          projectFields={projectFields}
-                          projectDescription={projectDescription}
-                          typeLookups={typeLookups}
-                          fieldDescriptions={fieldDescriptions}
-                          lookupDescriptions={lookupDescriptions}
-                          handleProjectRecordShow={handleProjectRecordShow}
-                          handleAnalysisShow={handleAnalysisShow}
-                        />
-                      </Tab.Pane>
-                    </Tab.Content>
-                  </Tab.Container>
-                </Tab.Pane>
-              ))}
-            </Tab.Content>
-          </Tab.Container>
+          {!project ? (
+            <LandingPage />
+          ) : (
+            <Tab.Container
+              activeKey={project.code}
+              mountOnEnter
+              unmountOnExit
+              transition={false}
+            >
+              <Tab.Content className="h-100">
+                {projects.map((p) => (
+                  <Tab.Pane key={p.code} eventKey={p.code} className="h-100">
+                    <ProjectPage
+                      {...props}
+                      darkMode={darkMode}
+                      typeLookups={typeLookups}
+                      lookupDescriptions={lookupDescriptions}
+                      project={p.code}
+                      tabKey={tabKey}
+                      recordTabKey={recordTabKey}
+                      analysisTabKey={analysisTabKey}
+                      recordID={recordID}
+                      analysisID={analysisID}
+                      handleProjectRecordShow={handleProjectRecordShow}
+                      handleAnalysisShow={handleAnalysisShow}
+                      handleProjectRecordHide={handleProjectRecordHide}
+                      handleAnalysisHide={handleAnalysisHide}
+                      recordDetailTabKey={recordDetailTabKey}
+                      setRecordDetailTabKey={setRecordDetailTabKey}
+                      recordDataPanelTabKey={recordDataPanelTabKey}
+                      setRecordDataPanelTabKey={setRecordDataPanelTabKey}
+                      analysisDetailTabKey={analysisDetailTabKey}
+                      setAnalysisDetailTabKey={setAnalysisDetailTabKey}
+                      analysisDataPanelTabKey={analysisDataPanelTabKey}
+                      setAnalysisDataPanelTabKey={setAnalysisDataPanelTabKey}
+                    />
+                  </Tab.Pane>
+                ))}
+              </Tab.Content>
+            </Tab.Container>
+          )}
         </Container>
       </div>
     </div>

--- a/lib/Onyx.tsx
+++ b/lib/Onyx.tsx
@@ -133,7 +133,7 @@ function App(props: OnyxProps) {
       .map(
         (projectPermission: ProjectPermissionType) => projectPermission.project
       )
-      .sort();
+      .sort() as string[];
   }, [projectPermissionsResponse]);
 
   // Set the first project as the default
@@ -205,110 +205,161 @@ function App(props: OnyxProps) {
       />
       <div className="h-100" style={{ paddingTop: "60px" }}>
         <Container fluid className="h-100 p-2">
-          <Tab.Container activeKey={tabKey} mountOnEnter transition={false}>
+          <Tab.Container
+            activeKey={project}
+            mountOnEnter
+            unmountOnExit
+            transition={false}
+          >
             <Tab.Content className="h-100">
-              <Tab.Pane eventKey={OnyxTabKeys.USER} className="h-100">
-                <User {...props} project={project} darkMode={darkMode} />
-              </Tab.Pane>
-              <Tab.Pane eventKey={OnyxTabKeys.SITE} className="h-100">
-                <Site {...props} project={project} darkMode={darkMode} />
-              </Tab.Pane>
-              <Tab.Pane eventKey={OnyxTabKeys.RECORDS} className="h-100">
-                <Tab.Container activeKey={recordTabKey} transition={false}>
-                  <Tab.Content className="h-100">
-                    <Tab.Pane eventKey={RecordTabKeys.LIST} className="h-100">
-                      <Results
-                        {...pageProps}
-                        projectFields={projectFields}
-                        projectDescription={projectDescription}
-                        typeLookups={typeLookups}
-                        fieldDescriptions={fieldDescriptions}
-                        lookupDescriptions={lookupDescriptions}
-                        handleProjectRecordShow={handleProjectRecordShow}
-                        handleAnalysisShow={handleAnalysisShow}
-                        title="Records"
-                        searchPath={`projects/${project}`}
-                      />
-                    </Tab.Pane>
-                    <Tab.Pane
-                      eventKey={RecordTabKeys.DETAIL}
-                      className="h-100"
-                      unmountOnExit
-                    >
-                      <ProjectRecord
-                        {...pageProps}
-                        projectFields={projectFields}
-                        projectDescription={projectDescription}
-                        typeLookups={typeLookups}
-                        fieldDescriptions={fieldDescriptions}
-                        lookupDescriptions={lookupDescriptions}
-                        handleProjectRecordShow={handleProjectRecordShow}
-                        handleAnalysisShow={handleAnalysisShow}
-                        ID={recordID}
-                        tabKey={recordDetailTabKey}
-                        setTabKey={setRecordDetailTabKey}
-                        dataPanelTabKey={recordDataPanelTabKey}
-                        setDataPanelTabKey={setRecordDataPanelTabKey}
-                        onHide={handleProjectRecordHide}
-                      />
-                    </Tab.Pane>
-                  </Tab.Content>
-                </Tab.Container>
-              </Tab.Pane>
-              <Tab.Pane eventKey={OnyxTabKeys.ANALYSES} className="h-100">
-                <Tab.Container activeKey={analysisTabKey} transition={false}>
-                  <Tab.Content className="h-100">
-                    <Tab.Pane eventKey={AnalysisTabKeys.LIST} className="h-100">
-                      <Results
-                        {...pageProps}
-                        projectFields={analysisFields}
-                        projectDescription={projectDescription}
-                        typeLookups={typeLookups}
-                        fieldDescriptions={analysisDescriptions}
-                        lookupDescriptions={lookupDescriptions}
-                        handleProjectRecordShow={handleProjectRecordShow}
-                        handleAnalysisShow={handleAnalysisShow}
-                        title="Analyses"
-                        searchPath={`projects/${project}/analysis`}
-                      />
-                    </Tab.Pane>
-                    <Tab.Pane
-                      eventKey={AnalysisTabKeys.DETAIL}
-                      className="h-100"
-                      unmountOnExit
-                    >
-                      <Analysis
-                        {...pageProps}
-                        projectFields={analysisFields}
-                        projectDescription={projectDescription}
-                        typeLookups={typeLookups}
-                        fieldDescriptions={analysisDescriptions}
-                        lookupDescriptions={lookupDescriptions}
-                        handleProjectRecordShow={handleProjectRecordShow}
-                        handleAnalysisShow={handleAnalysisShow}
-                        ID={analysisID}
-                        tabKey={analysisDetailTabKey}
-                        setTabKey={setAnalysisDetailTabKey}
-                        dataPanelTabKey={analysisDataPanelTabKey}
-                        setDataPanelTabKey={setAnalysisDataPanelTabKey}
-                        onHide={handleAnalysisHide}
-                      />
-                    </Tab.Pane>
-                  </Tab.Content>
-                </Tab.Container>
-              </Tab.Pane>
-              <Tab.Pane eventKey={OnyxTabKeys.GRAPHS} className="h-100">
-                <Graphs
-                  {...pageProps}
-                  projectFields={projectFields}
-                  projectDescription={projectDescription}
-                  typeLookups={typeLookups}
-                  fieldDescriptions={fieldDescriptions}
-                  lookupDescriptions={lookupDescriptions}
-                  handleProjectRecordShow={handleProjectRecordShow}
-                  handleAnalysisShow={handleAnalysisShow}
-                />
-              </Tab.Pane>
+              {projects.map((project) => (
+                <Tab.Pane key={project} eventKey={project} className="h-100">
+                  <Tab.Container
+                    activeKey={tabKey}
+                    mountOnEnter
+                    transition={false}
+                  >
+                    <Tab.Content className="h-100">
+                      <Tab.Pane eventKey={OnyxTabKeys.USER} className="h-100">
+                        <User
+                          {...props}
+                          project={project}
+                          darkMode={darkMode}
+                        />
+                      </Tab.Pane>
+                      <Tab.Pane eventKey={OnyxTabKeys.SITE} className="h-100">
+                        <Site
+                          {...props}
+                          project={project}
+                          darkMode={darkMode}
+                        />
+                      </Tab.Pane>
+                      <Tab.Pane
+                        eventKey={OnyxTabKeys.RECORDS}
+                        className="h-100"
+                      >
+                        <Tab.Container
+                          activeKey={recordTabKey}
+                          transition={false}
+                        >
+                          <Tab.Content className="h-100">
+                            <Tab.Pane
+                              eventKey={RecordTabKeys.LIST}
+                              className="h-100"
+                            >
+                              <Results
+                                {...pageProps}
+                                projectFields={projectFields}
+                                projectDescription={projectDescription}
+                                typeLookups={typeLookups}
+                                fieldDescriptions={fieldDescriptions}
+                                lookupDescriptions={lookupDescriptions}
+                                handleProjectRecordShow={
+                                  handleProjectRecordShow
+                                }
+                                handleAnalysisShow={handleAnalysisShow}
+                                title="Records"
+                                searchPath={`projects/${project}`}
+                              />
+                            </Tab.Pane>
+                            <Tab.Pane
+                              eventKey={RecordTabKeys.DETAIL}
+                              className="h-100"
+                              unmountOnExit
+                            >
+                              <ProjectRecord
+                                {...pageProps}
+                                projectFields={projectFields}
+                                projectDescription={projectDescription}
+                                typeLookups={typeLookups}
+                                fieldDescriptions={fieldDescriptions}
+                                lookupDescriptions={lookupDescriptions}
+                                handleProjectRecordShow={
+                                  handleProjectRecordShow
+                                }
+                                handleAnalysisShow={handleAnalysisShow}
+                                ID={recordID}
+                                tabKey={recordDetailTabKey}
+                                setTabKey={setRecordDetailTabKey}
+                                dataPanelTabKey={recordDataPanelTabKey}
+                                setDataPanelTabKey={setRecordDataPanelTabKey}
+                                onHide={handleProjectRecordHide}
+                              />
+                            </Tab.Pane>
+                          </Tab.Content>
+                        </Tab.Container>
+                      </Tab.Pane>
+                      <Tab.Pane
+                        eventKey={OnyxTabKeys.ANALYSES}
+                        className="h-100"
+                      >
+                        <Tab.Container
+                          activeKey={analysisTabKey}
+                          transition={false}
+                        >
+                          <Tab.Content className="h-100">
+                            <Tab.Pane
+                              eventKey={AnalysisTabKeys.LIST}
+                              className="h-100"
+                            >
+                              <Results
+                                {...pageProps}
+                                projectFields={analysisFields}
+                                projectDescription={projectDescription}
+                                typeLookups={typeLookups}
+                                fieldDescriptions={analysisDescriptions}
+                                lookupDescriptions={lookupDescriptions}
+                                handleProjectRecordShow={
+                                  handleProjectRecordShow
+                                }
+                                handleAnalysisShow={handleAnalysisShow}
+                                title="Analyses"
+                                searchPath={`projects/${project}/analysis`}
+                              />
+                            </Tab.Pane>
+                            <Tab.Pane
+                              eventKey={AnalysisTabKeys.DETAIL}
+                              className="h-100"
+                              unmountOnExit
+                            >
+                              <Analysis
+                                {...pageProps}
+                                projectFields={analysisFields}
+                                projectDescription={projectDescription}
+                                typeLookups={typeLookups}
+                                fieldDescriptions={analysisDescriptions}
+                                lookupDescriptions={lookupDescriptions}
+                                handleProjectRecordShow={
+                                  handleProjectRecordShow
+                                }
+                                handleAnalysisShow={handleAnalysisShow}
+                                ID={analysisID}
+                                tabKey={analysisDetailTabKey}
+                                setTabKey={setAnalysisDetailTabKey}
+                                dataPanelTabKey={analysisDataPanelTabKey}
+                                setDataPanelTabKey={setAnalysisDataPanelTabKey}
+                                onHide={handleAnalysisHide}
+                              />
+                            </Tab.Pane>
+                          </Tab.Content>
+                        </Tab.Container>
+                      </Tab.Pane>
+                      <Tab.Pane eventKey={OnyxTabKeys.GRAPHS} className="h-100">
+                        <Graphs
+                          {...pageProps}
+                          projectFields={projectFields}
+                          projectDescription={projectDescription}
+                          typeLookups={typeLookups}
+                          fieldDescriptions={fieldDescriptions}
+                          lookupDescriptions={lookupDescriptions}
+                          handleProjectRecordShow={handleProjectRecordShow}
+                          handleAnalysisShow={handleAnalysisShow}
+                        />
+                      </Tab.Pane>
+                    </Tab.Content>
+                  </Tab.Container>
+                </Tab.Pane>
+              ))}
             </Tab.Content>
           </Tab.Container>
         </Container>

--- a/lib/Onyx.tsx
+++ b/lib/Onyx.tsx
@@ -318,7 +318,7 @@ function App(props: OnyxProps) {
         {...props}
         project={project?.code || ""}
         projectObj={project}
-        projectObjs={projects}
+        projectList={projects}
         handleProjectChange={handleProjectChange}
         tabKey={tabKey}
         setTabKey={setTabKey}

--- a/lib/Onyx.tsx
+++ b/lib/Onyx.tsx
@@ -267,15 +267,23 @@ function App(props: OnyxProps) {
     );
   }, [lookupsResponse]);
 
-  // Get the list of projects
+  // Get the project list
   const projects = useMemo(() => {
     if (projectPermissionsResponse?.status !== "success") return [];
-    return projectPermissionsResponse.data
+
+    // Map the project permissions to a list of projects
+    // Each item in the list is an object with a code and name
+    const ps = projectPermissionsResponse.data
       .map((projectPermission: ProjectPermissionType) => ({
         code: projectPermission.project,
         name: projectPermission.name,
       }))
-      .sort() as Project[];
+      .sort((a: Project, b: Project) =>
+        a.code < b.code ? -1 : 1
+      ) as Project[];
+
+    // Deduplicate the project list by code
+    return [...new Map(ps.map((p) => [p.code, p])).values()];
   }, [projectPermissionsResponse]);
 
   // Set the first project as the default

--- a/lib/components/FilterPanel.tsx
+++ b/lib/components/FilterPanel.tsx
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useState } from "react";
+import { useState } from "react";
 import Button from "react-bootstrap/Button";
 import ButtonGroup from "react-bootstrap/ButtonGroup";
 import Card from "react-bootstrap/Card";
@@ -67,13 +67,6 @@ function FilterPanel(props: FilterPanelProps) {
   const [editFilter, setEditFilter] = useState({} as FilterConfig);
   const [editIndex, setEditIndex] = useState(0);
   const [removeAllModalShow, setRemoveAllModalShow] = useState(false);
-
-  // Clear parameters when project changes
-  useLayoutEffect(() => {
-    setEditMode(false);
-    setEditFilter({} as FilterConfig);
-    setEditIndex(0);
-  }, [props.project]);
 
   const handleEditMode = (filter: FilterConfig, index: number) => {
     setEditMode(true);

--- a/lib/components/Header.tsx
+++ b/lib/components/Header.tsx
@@ -8,12 +8,13 @@ import Stack from "react-bootstrap/Stack";
 import { MdDarkMode, MdJoinInner, MdLightMode } from "react-icons/md";
 import { useProfileQuery } from "../api";
 import { PageProps } from "../interfaces";
-import { OnyxTabKeys } from "../types";
+import { OnyxTabKeys, Project } from "../types";
+import { TextQueryHandler } from "./QueryHandler";
 
 interface HeaderProps extends PageProps {
-  projectName: string;
-  projectList: string[];
-  handleProjectChange: (p: string) => void;
+  projectObj?: Project;
+  projectObjs: Project[];
+  handleProjectChange: (p: Project) => void;
   tabKey: string;
   setTabKey: (k: string) => void;
   handleThemeChange: () => void;
@@ -21,10 +22,16 @@ interface HeaderProps extends PageProps {
   handleAnalysisHide: () => void;
 }
 
-function HeaderText({ label, value }: { label: string; value: string }) {
+function HeaderText({
+  label,
+  value,
+}: {
+  label: string;
+  value?: string | JSX.Element;
+}) {
   return (
     <Navbar.Text>
-      {label}: <span className="text-light">{value || "None"}</span>
+      {label}: <span className="text-light">{value}</span>
     </Navbar.Text>
   );
 }
@@ -107,15 +114,20 @@ function Header(props: HeaderProps) {
         <Navbar.Collapse id="responsive-navbar-nav">
           <Nav className="me-auto">
             <NavDropdown
-              title={<HeaderText label="Project" value={props.projectName} />}
+              title={
+                <HeaderText
+                  label="Project"
+                  value={props.projectObj?.name || "Not Selected"}
+                />
+              }
               style={{ color: "white" }}
             >
-              {props.projectList.map((p) => (
+              {props.projectObjs.map((p) => (
                 <NavDropdown.Item
-                  key={p}
+                  key={p.code}
                   onClick={() => props.handleProjectChange(p)}
                 >
-                  {p}
+                  {p.name}
                 </NavDropdown.Item>
               ))}
             </NavDropdown>
@@ -125,11 +137,12 @@ function Header(props: HeaderProps) {
                   <HeaderText
                     label="User"
                     value={
-                      isFetching
-                        ? "Loading..."
-                        : error
-                        ? "Failed to load"
-                        : profile.username
+                      <TextQueryHandler
+                        isFetching={isFetching}
+                        error={error as Error}
+                      >
+                        {profile.username}
+                      </TextQueryHandler>
                     }
                   />
                 </Nav.Link>
@@ -137,11 +150,12 @@ function Header(props: HeaderProps) {
                   <HeaderText
                     label="Site"
                     value={
-                      isFetching
-                        ? "Loading..."
-                        : error
-                        ? "Failed to load"
-                        : profile.site
+                      <TextQueryHandler
+                        isFetching={isFetching}
+                        error={error as Error}
+                      >
+                        {profile.site}
+                      </TextQueryHandler>
                     }
                   />
                 </Nav.Link>

--- a/lib/components/Header.tsx
+++ b/lib/components/Header.tsx
@@ -13,7 +13,7 @@ import { TextQueryHandler } from "./QueryHandler";
 
 interface HeaderProps extends PageProps {
   projectObj?: Project;
-  projectObjs: Project[];
+  projectList: Project[];
   handleProjectChange: (p: Project) => void;
   tabKey: string;
   setTabKey: (k: string) => void;
@@ -122,7 +122,7 @@ function Header(props: HeaderProps) {
               }
               style={{ color: "white" }}
             >
-              {props.projectObjs.map((p) => (
+              {props.projectList.map((p) => (
                 <NavDropdown.Item
                   key={p.code}
                   onClick={() => props.handleProjectChange(p)}

--- a/lib/components/PageTitle.tsx
+++ b/lib/components/PageTitle.tsx
@@ -1,13 +1,13 @@
 interface PageTitleProps {
   title: string;
-  projectDescription: string;
+  description: string;
 }
 
 function PageTitle(props: PageTitleProps) {
   return (
     <span>
       {props.title} <span className="onyx-text-pink">|</span>{" "}
-      <span className="text-muted">{props.projectDescription}</span>
+      <span className="text-muted">{props.description}</span>
     </span>
   );
 }

--- a/lib/components/QueryHandler.tsx
+++ b/lib/components/QueryHandler.tsx
@@ -1,19 +1,14 @@
-import React, { useEffect, useState } from "react";
 import Alert from "react-bootstrap/Alert";
 import Spinner from "react-bootstrap/Spinner";
 import Stack from "react-bootstrap/Stack";
 import { ErrorResponse, SuccessResponse } from "../types";
+import { useDelayedValue } from "../utils/hooks";
 
 function LoadingSpinner() {
-  const [showAlert, setShowAlert] = useState(false);
-
-  useEffect(() => {
-    const timer = setTimeout(() => setShowAlert(true), 500);
-    return () => clearTimeout(timer);
-  });
+  const showAlert = useDelayedValue();
 
   return showAlert ? (
-    <div className="d-flex justify-content-center">
+    <div className="h-100 d-flex justify-content-center align-items-center">
       <Stack direction="horizontal" gap={2}>
         <Spinner />
         <span>Loading...</span>

--- a/lib/components/QueryHandler.tsx
+++ b/lib/components/QueryHandler.tsx
@@ -2,7 +2,20 @@ import Alert from "react-bootstrap/Alert";
 import Spinner from "react-bootstrap/Spinner";
 import Stack from "react-bootstrap/Stack";
 import { ErrorResponse, SuccessResponse } from "../types";
-import { useDelayedValue } from "../utils/hooks";
+import { useDelayedValue, useCyclicValue } from "../utils/hooks";
+
+function LoadingText() {
+  const ellipsisCount = useCyclicValue(0, 3);
+
+  return (
+    <span>
+      Loading
+      <pre style={{ display: "inline" }}>
+        {".".repeat(ellipsisCount) + " ".repeat(3 - ellipsisCount)}
+      </pre>
+    </span>
+  );
+}
 
 function LoadingSpinner() {
   const showAlert = useDelayedValue();
@@ -11,7 +24,7 @@ function LoadingSpinner() {
     <div className="h-100 d-flex justify-content-center align-items-center">
       <Stack direction="horizontal" gap={2}>
         <Spinner />
-        <span>Loading...</span>
+        <LoadingText />
       </Stack>
     </div>
   ) : (
@@ -40,6 +53,24 @@ function ErrorMessages(props: ErrorMessagesProps) {
         )
       )}
     </>
+  );
+}
+
+export function TextQueryHandler({
+  isFetching,
+  error,
+  children,
+}: {
+  isFetching: boolean;
+  error: Error | null;
+  children: React.ReactNode;
+}) {
+  return isFetching ? (
+    <LoadingText />
+  ) : error ? (
+    <span>Not Found</span>
+  ) : (
+    (children as JSX.Element)
   );
 }
 

--- a/lib/components/ResultsPanel.tsx
+++ b/lib/components/ResultsPanel.tsx
@@ -70,7 +70,10 @@ function ResultsPanel(props: ResultsPanelProps) {
       <Card.Header>
         <Stack gap={2} direction="horizontal">
           <SidebarButton {...props} />
-          <PageTitle {...props} />
+          <PageTitle
+            title={props.title}
+            description={props.projectDescription}
+          />
         </Stack>
       </Card.Header>
       <Card.Body className="h-100 p-2 overflow-y-auto">

--- a/lib/components/TransformsPanel.tsx
+++ b/lib/components/TransformsPanel.tsx
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useState } from "react";
+import { useState } from "react";
 import Button from "react-bootstrap/Button";
 import ButtonGroup from "react-bootstrap/ButtonGroup";
 import Card from "react-bootstrap/Card";
@@ -20,11 +20,6 @@ interface TransformsPanelProps extends DataProps {
 
 function TransformsPanel(props: TransformsPanelProps) {
   const [editMode, setEditMode] = useState(false);
-
-  // Clear parameters when project changes
-  useLayoutEffect(() => {
-    setEditMode(false);
-  }, [props.project]);
 
   const handleTransformsChange = (action: string) => {
     props.setTransform(action);

--- a/lib/pages/Graphs.tsx
+++ b/lib/pages/Graphs.tsx
@@ -518,7 +518,10 @@ function Graphs(props: DataProps) {
         <Card.Header>
           <Stack direction="horizontal" gap={1}>
             <span className="me-auto">
-              <PageTitle {...props} title="Graphs" />
+              <PageTitle
+                title="Graphs"
+                description={props.projectDescription}
+              />
             </span>
             <Button
               size="sm"

--- a/lib/pages/Graphs.tsx
+++ b/lib/pages/Graphs.tsx
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import Button from "react-bootstrap/Button";
 import Card from "react-bootstrap/Card";
 import Col from "react-bootstrap/Col";
@@ -401,11 +401,6 @@ function Graphs(props: DataProps) {
   const handleRefresh = () => {
     setRefresh(refresh ? 0 : 1);
   };
-
-  // Reset graphs when project changes
-  useLayoutEffect(() => {
-    setGraphConfigList(defaultGraphConfig());
-  }, [props.project]);
 
   const handleGraphConfigTypeChange = (
     e: React.ChangeEvent<HTMLSelectElement>,

--- a/lib/pages/Results.tsx
+++ b/lib/pages/Results.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import Container from "react-bootstrap/Container";
 import Stack from "react-bootstrap/Stack";
 import { useResultsQuery } from "../api";
@@ -34,15 +34,6 @@ function Results(props: ResultsProps) {
   );
 
   const { isFetching, error, data, refetch } = useResultsQuery(queryProps);
-
-  // Clear parameters when project changes
-  useLayoutEffect(() => {
-    setSearchInput("");
-    setFilterList([]);
-    setTransform("Summarise");
-    setTransformList([]);
-    setSearchParameters("");
-  }, [props.project]);
 
   const searchParams = useMemo(
     () =>

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,3 +1,8 @@
+export enum Theme {
+  LIGHT = "light",
+  DARK = "dark",
+}
+
 export enum OnyxTabKeys {
   USER = "user-tab",
   SITE = "site-tab",
@@ -64,6 +69,11 @@ export type FieldType =
 
 export type GraphType = "line" | "bar" | "pie" | "";
 
+export type Project = {
+  code: string;
+  name: string;
+};
+
 export type ProjectField = {
   type: FieldType;
   description: string;
@@ -119,6 +129,7 @@ export type SummaryType = Record<"count", number> &
 
 export type ProjectPermissionType = {
   project: string;
+  name: string;
   scope: string;
   actions: string[];
 };

--- a/lib/utils/hooks.ts
+++ b/lib/utils/hooks.ts
@@ -22,6 +22,19 @@ export const useDelayedValue = (delay?: number) => {
   return showValue;
 };
 
+export const useCyclicValue = (start: number, end: number, pause?: number) => {
+  const [value, setValue] = useState(start);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setValue((v) => (v + 1) % (end + 1));
+    }, pause || 500);
+    return () => clearInterval(interval);
+  });
+
+  return value;
+};
+
 export const useQueryRefresh = (
   refresh: number | null,
   dataUpdatedAt: number,

--- a/lib/utils/hooks.ts
+++ b/lib/utils/hooks.ts
@@ -1,19 +1,28 @@
 import { useEffect, useState } from "react";
 
-const useDebouncedValue = (inputValue: string, delay: number) => {
+export const useDebouncedValue = (inputValue: string, delay: number) => {
   const [debouncedValue, setDebouncedValue] = useState(inputValue);
+
   useEffect(() => {
-    const handler = setTimeout(() => {
-      setDebouncedValue(inputValue);
-    }, delay);
-    return () => {
-      clearTimeout(handler);
-    };
+    const timeout = setTimeout(() => setDebouncedValue(inputValue), delay);
+    return () => clearTimeout(timeout);
   }, [inputValue, delay]);
+
   return debouncedValue;
 };
 
-const useQueryRefresh = (
+export const useDelayedValue = (delay?: number) => {
+  const [showValue, setShowValue] = useState(false);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setShowValue(true), delay || 500);
+    return () => clearTimeout(timer);
+  });
+
+  return showValue;
+};
+
+export const useQueryRefresh = (
   refresh: number | null,
   dataUpdatedAt: number,
   errorUpdatedAt: number,
@@ -38,5 +47,3 @@ const useQueryRefresh = (
     );
   }, [dataUpdatedAt, errorUpdatedAt, setLastUpdated]);
 };
-
-export { useDebouncedValue, useQueryRefresh };


### PR DESCRIPTION
* Added landing page when no project is selected.
* Restructured app to put each projects component tree into a separate tab, that is mounted/unmounted on project switch. This enables a much cleaner project switch, without needing layout effects to update state. Also means in future we could maintain state across multiple projects simultaneously. 
* Improved loading animations.
* Added `TextQueryHandler` for text-field loading info.
* Added `useDelayedValue` and `useCyclicValue` hooks.