### PR TITLE
Default search fields, resize bar, improved search

### DIFF
--- a/lib/Onyx.css
+++ b/lib/Onyx.css
@@ -70,21 +70,41 @@
   font-family: var(--bs-body-font-family);
 }
 
-.parent {
+.resizer {
+  cursor: col-resize;
+  height: 100%;
+  width: 14px;
+  position: absolute;
+  top: 0;
+  right: -7px;
   display: flex;
-  width: 100%;
+  align-items: center;
+  justify-content: center;
+  z-index: 10;
+  border-radius: 7px;
 }
 
-.left-col {
-  resize: horizontal;
-  overflow: auto;
-  min-width: 220px;
-  width: 300px;
+[data-bs-theme=light] .resizer {
+  background-color: var(--bs-gray-300);
 }
 
-.right-col {
-  flex-grow: 1;
-  min-width: 500px;
+[data-bs-theme=dark] .resizer {
+  background-color: var(--bs-gray-900);
+}
+
+.resizer::before {
+  content: "||";
+  font-size: 12px;
+  font-weight: bold;
+  line-height: 1;
+}
+
+[data-bs-theme=light] .resizer::before {
+  color: rgba(0, 0, 0, 0.5);
+}
+
+[data-bs-theme=dark] .resizer::before {
+  color: rgba(255, 255, 255, 0.7);
 }
 
 [data-bs-theme=light] .onyx-border {

--- a/lib/Onyx.tsx
+++ b/lib/Onyx.tsx
@@ -14,6 +14,7 @@ import Fade from "react-bootstrap/Fade";
 import { useFieldsInfo } from "./api/hooks";
 import Header from "./components/Header";
 import PageTitle from "./components/PageTitle";
+import QueryHandler from "./components/QueryHandler";
 import { OnyxProps, ProjectProps } from "./interfaces";
 import Analysis from "./pages/Analysis";
 import Graphs from "./pages/Graphs";
@@ -25,7 +26,6 @@ import {
   AnalysisTabKeys,
   AnalysisDetailTabKeys,
   DataPanelTabKeys,
-  Lookup,
   OnyxTabKeys,
   Project,
   ProjectPermissionGroup,
@@ -33,7 +33,6 @@ import {
   RecordDetailTabKeys,
   TabState,
   Themes,
-  TypeObject,
   RecentlyViewed,
 } from "./types";
 import { useDelayedValue } from "./utils/hooks";
@@ -53,95 +52,104 @@ interface ProjectPageProps extends ProjectProps {
 
 function ProjectPage(props: ProjectPageProps) {
   // Get project information
-  const { data: fieldsResponse } = useFieldsQuery(props);
-  const { description, fields } = useFieldsInfo(fieldsResponse);
+  const { isFetching, error, data: fieldsResponse } = useFieldsQuery(props);
+  const { description, fields, defaultFields } = useFieldsInfo(fieldsResponse);
 
   // Get project analyses information
   const { data: analysisFieldsResponse } = useAnalysisFieldsQuery(props);
-  const { fields: analysisFields } = useFieldsInfo(analysisFieldsResponse);
+  const { fields: analysisFields, defaultFields: defaultAnalysisFields } =
+    useFieldsInfo(analysisFieldsResponse);
 
   return (
-    <Tab.Container
-      activeKey={props.tabState.tabKey}
-      mountOnEnter
-      transition={false}
-    >
-      <Tab.Content className="h-100">
-        <Tab.Pane eventKey={OnyxTabKeys.USER} className="h-100">
-          <User {...props} />
-        </Tab.Pane>
-        <Tab.Pane eventKey={OnyxTabKeys.SITE} className="h-100">
-          <Site {...props} />
-        </Tab.Pane>
-        <Tab.Pane eventKey={OnyxTabKeys.RECORDS} className="h-100">
-          <Tab.Container
-            activeKey={props.tabState.recordTabKey}
-            transition={false}
-          >
-            <Tab.Content className="h-100">
-              <Tab.Pane eventKey={RecordTabKeys.LIST} className="h-100">
-                <Results
-                  {...props}
-                  fields={fields}
-                  projectDescription={description}
-                  title="Records"
-                  commandBase={`onyx filter ${props.project.code}`}
-                  searchPath={`projects/${props.project.code}`}
-                />
-              </Tab.Pane>
-              <Tab.Pane
-                eventKey={RecordTabKeys.DETAIL}
-                className="h-100"
-                unmountOnExit
-              >
-                <ProjectRecord
-                  {...props}
-                  fields={fields}
-                  projectDescription={description}
-                  ID={props.tabState.recordID}
-                  onHide={props.handleProjectRecordHide}
-                />
-              </Tab.Pane>
-            </Tab.Content>
-          </Tab.Container>
-        </Tab.Pane>
-        <Tab.Pane eventKey={OnyxTabKeys.ANALYSES} className="h-100">
-          <Tab.Container
-            activeKey={props.tabState.analysisTabKey}
-            transition={false}
-          >
-            <Tab.Content className="h-100">
-              <Tab.Pane eventKey={AnalysisTabKeys.LIST} className="h-100">
-                <Results
-                  {...props}
-                  fields={analysisFields}
-                  projectDescription={description}
-                  title="Analyses"
-                  commandBase={`onyx filter-analysis ${props.project.code}`}
-                  searchPath={`projects/${props.project.code}/analysis`}
-                />
-              </Tab.Pane>
-              <Tab.Pane
-                eventKey={AnalysisTabKeys.DETAIL}
-                className="h-100"
-                unmountOnExit
-              >
-                <Analysis
-                  {...props}
-                  fields={analysisFields}
-                  projectDescription={description}
-                  ID={props.tabState.analysisID}
-                  onHide={props.handleAnalysisHide}
-                />
-              </Tab.Pane>
-            </Tab.Content>
-          </Tab.Container>
-        </Tab.Pane>
-        <Tab.Pane eventKey={OnyxTabKeys.GRAPHS} className="h-100">
-          <Graphs {...props} fields={fields} projectDescription={description} />
-        </Tab.Pane>
-      </Tab.Content>
-    </Tab.Container>
+    <QueryHandler isFetching={isFetching} error={error} data={fieldsResponse}>
+      <Tab.Container
+        activeKey={props.tabState.tabKey}
+        mountOnEnter
+        transition={false}
+      >
+        <Tab.Content className="h-100">
+          <Tab.Pane eventKey={OnyxTabKeys.USER} className="h-100">
+            <User {...props} />
+          </Tab.Pane>
+          <Tab.Pane eventKey={OnyxTabKeys.SITE} className="h-100">
+            <Site {...props} />
+          </Tab.Pane>
+          <Tab.Pane eventKey={OnyxTabKeys.RECORDS} className="h-100">
+            <Tab.Container
+              activeKey={props.tabState.recordTabKey}
+              transition={false}
+            >
+              <Tab.Content className="h-100">
+                <Tab.Pane eventKey={RecordTabKeys.LIST} className="h-100">
+                  <Results
+                    {...props}
+                    fields={fields}
+                    defaultFields={defaultFields}
+                    projectDescription={description}
+                    title="Records"
+                    commandBase={`onyx filter ${props.project.code}`}
+                    searchPath={`projects/${props.project.code}`}
+                  />
+                </Tab.Pane>
+                <Tab.Pane
+                  eventKey={RecordTabKeys.DETAIL}
+                  className="h-100"
+                  unmountOnExit
+                >
+                  <ProjectRecord
+                    {...props}
+                    fields={fields}
+                    projectDescription={description}
+                    ID={props.tabState.recordID}
+                    onHide={props.handleProjectRecordHide}
+                  />
+                </Tab.Pane>
+              </Tab.Content>
+            </Tab.Container>
+          </Tab.Pane>
+          <Tab.Pane eventKey={OnyxTabKeys.ANALYSES} className="h-100">
+            <Tab.Container
+              activeKey={props.tabState.analysisTabKey}
+              transition={false}
+            >
+              <Tab.Content className="h-100">
+                <Tab.Pane eventKey={AnalysisTabKeys.LIST} className="h-100">
+                  <Results
+                    {...props}
+                    fields={analysisFields}
+                    defaultFields={defaultAnalysisFields}
+                    projectDescription={description}
+                    title="Analyses"
+                    commandBase={`onyx filter-analysis ${props.project.code}`}
+                    searchPath={`projects/${props.project.code}/analysis`}
+                  />
+                </Tab.Pane>
+                <Tab.Pane
+                  eventKey={AnalysisTabKeys.DETAIL}
+                  className="h-100"
+                  unmountOnExit
+                >
+                  <Analysis
+                    {...props}
+                    fields={analysisFields}
+                    projectDescription={description}
+                    ID={props.tabState.analysisID}
+                    onHide={props.handleAnalysisHide}
+                  />
+                </Tab.Pane>
+              </Tab.Content>
+            </Tab.Container>
+          </Tab.Pane>
+          <Tab.Pane eventKey={OnyxTabKeys.GRAPHS} className="h-100">
+            <Graphs
+              {...props}
+              fields={fields}
+              projectDescription={description}
+            />
+          </Tab.Pane>
+        </Tab.Content>
+      </Tab.Container>
+    </QueryHandler>
   );
 }
 
@@ -220,7 +228,7 @@ function App(props: OnyxProps) {
   const typeLookups = useMemo(() => {
     if (typesResponse?.status !== "success") return new Map<string, string[]>();
     return new Map<string, string[]>(
-      typesResponse.data.map((type: TypeObject) => [type.type, type.lookups])
+      typesResponse.data.map((type) => [type.type, type.lookups])
     );
   }, [typesResponse]);
 
@@ -228,10 +236,7 @@ function App(props: OnyxProps) {
   const lookupDescriptions = useMemo(() => {
     if (lookupsResponse?.status !== "success") return new Map<string, string>();
     return new Map<string, string>(
-      lookupsResponse.data.map((lookup: Lookup) => [
-        lookup.lookup,
-        lookup.description,
-      ])
+      lookupsResponse.data.map((lookup) => [lookup.lookup, lookup.description])
     );
   }, [lookupsResponse]);
 

--- a/lib/api/hooks.ts
+++ b/lib/api/hooks.ts
@@ -27,13 +27,16 @@ function flattenFields(fields: Record<string, Field>) {
   return flatFields;
 }
 
-const useFieldsInfo = (data: DetailResponse<Fields> | ErrorResponse) => {
+const useFieldsInfo = (
+  data: DetailResponse<Fields> | ErrorResponse | undefined
+) => {
   return useMemo(() => {
     if (data?.status !== "success") {
       return {
         name: "",
         description: "",
         fields: new Map<string, Field>(),
+        defaultFields: [] as string[],
       };
     }
 
@@ -46,7 +49,10 @@ const useFieldsInfo = (data: DetailResponse<Fields> | ErrorResponse) => {
     // A map of field names to their type, description, actions, values and nested fields
     const fields = new Map(Object.entries(flattenFields(data.data.fields)));
 
-    return { name, description, fields };
+    // The default GUI fields for the project
+    const defaultFields = data.data.default_gui_fields;
+
+    return { name, description, fields, defaultFields };
   }, [data]);
 };
 
@@ -60,7 +66,7 @@ const useFieldDescriptions = (fields: Map<string, Field>) => {
 };
 
 const useChoiceDescriptions = (
-  data: DetailResponse<Choices> | ErrorResponse
+  data: DetailResponse<Choices> | ErrorResponse | undefined
 ) => {
   // Get a map of choices to their descriptions
   return useMemo(() => {

--- a/lib/api/hooks.ts
+++ b/lib/api/hooks.ts
@@ -50,7 +50,7 @@ const useFieldsInfo = (
     const fields = new Map(Object.entries(flattenFields(data.data.fields)));
 
     // The default GUI fields for the project
-    const defaultFields = data.data.default_gui_fields;
+    const defaultFields = data.data.default_fields;
 
     return { name, description, fields, defaultFields };
   }, [data]);

--- a/lib/api/hooks.ts
+++ b/lib/api/hooks.ts
@@ -50,7 +50,7 @@ const useFieldsInfo = (
     const fields = new Map(Object.entries(flattenFields(data.data.fields)));
 
     // The default GUI fields for the project
-    const defaultFields = data.data.default_fields;
+    const defaultFields = data.data.default_fields || [];
 
     return { name, description, fields, defaultFields };
   }, [data]);

--- a/lib/api/index.ts
+++ b/lib/api/index.ts
@@ -344,8 +344,13 @@ const useCountQuery = (props: QueryProps) => {
   return useQuery({
     queryKey: ["count-detail", props.searchPath, props.searchParameters],
     queryFn: async () => {
+      // Remove include and exclude parameters from searchParameters
+      const searchParameters = new URLSearchParams(props.searchParameters);
+      searchParameters.delete("include");
+      searchParameters.delete("exclude");
+
       return props
-        .httpPathHandler(`${props.searchPath}/count/?${props.searchParameters}`)
+        .httpPathHandler(`${props.searchPath}/count/?${searchParameters}`)
         .then((response) => response.json());
     },
     enabled: !!(props.project && props.searchPath),

--- a/lib/api/index.ts
+++ b/lib/api/index.ts
@@ -9,6 +9,10 @@ import {
   ProjectPermissionGroup,
   Profile,
   HistoricalEntries,
+  Fields,
+  Choices,
+  Lookup,
+  TypeObject,
 } from "../types";
 import { formatFilters } from "../utils/functions";
 
@@ -39,7 +43,9 @@ interface GraphQueryProps extends ProjectProps {
 }
 
 /** Fetch types */
-const useTypesQuery = (props: OnyxProps) => {
+const useTypesQuery = (
+  props: OnyxProps
+): UseQueryResult<ListResponse<TypeObject> | ErrorResponse, Error> => {
   return useQuery({
     queryKey: ["type-list"],
     queryFn: async () => {
@@ -52,7 +58,9 @@ const useTypesQuery = (props: OnyxProps) => {
 };
 
 /** Fetch lookups */
-const useLookupsQuery = (props: OnyxProps) => {
+const useLookupsQuery = (
+  props: OnyxProps
+): UseQueryResult<ListResponse<Lookup> | ErrorResponse, Error> => {
   return useQuery({
     queryKey: ["lookup-list"],
     queryFn: async () => {
@@ -98,7 +106,9 @@ const useProjectPermissionsQuery = (
 };
 
 /** Fetch project fields */
-const useFieldsQuery = (props: ProjectProps) => {
+const useFieldsQuery = (
+  props: ProjectProps
+): UseQueryResult<DetailResponse<Fields> | ErrorResponse, Error> => {
   return useQuery({
     queryKey: ["project-fields-detail", props.project.code],
     queryFn: async () => {
@@ -112,7 +122,9 @@ const useFieldsQuery = (props: ProjectProps) => {
 };
 
 /** Fetch analysis fields */
-const useAnalysisFieldsQuery = (props: ProjectProps) => {
+const useAnalysisFieldsQuery = (
+  props: ProjectProps
+): UseQueryResult<DetailResponse<Fields> | ErrorResponse, Error> => {
   return useQuery({
     queryKey: ["analysis-fields-detail", props.project.code],
     queryFn: async () => {
@@ -126,7 +138,9 @@ const useAnalysisFieldsQuery = (props: ProjectProps) => {
 };
 
 /** Fetch choices for a field */
-const useChoicesQuery = (props: ChoiceProps) => {
+const useChoicesQuery = (
+  props: ChoiceProps
+): UseQueryResult<DetailResponse<Choices> | ErrorResponse, Error> => {
   return useQuery({
     queryKey: ["choices-detail", props.project.code, props.field],
     queryFn: async () => {

--- a/lib/components/Filter.tsx
+++ b/lib/components/Filter.tsx
@@ -1,4 +1,4 @@
-import React, { useState, Dispatch, SetStateAction } from "react";
+import React, { useState } from "react";
 import Button from "react-bootstrap/Button";
 import CloseButton from "react-bootstrap/CloseButton";
 import Form from "react-bootstrap/Form";
@@ -12,7 +12,8 @@ import { useFieldDescriptions } from "../api/hooks";
 interface FilterProps extends DataProps {
   filter: FilterConfig;
   index: number;
-  setFilterList: Dispatch<SetStateAction<FilterConfig[]>>;
+  filterList: FilterConfig[];
+  setFilterList: (filters: FilterConfig[]) => void;
   fieldList: string[];
   setEditMode: (value: boolean) => void;
   disableLookups?: boolean;
@@ -86,10 +87,10 @@ function Filter(props: FilterProps) {
       updatedFilter.value = updatedFilter.value.trim();
     }
 
-    props.setFilterList((prevState) => [
-      ...prevState.slice(0, props.index),
+    props.setFilterList([
+      ...props.filterList.slice(0, props.index),
       updatedFilter,
-      ...prevState.slice(props.index + 1),
+      ...props.filterList.slice(props.index + 1),
     ]);
     props.setEditMode(false);
   };

--- a/lib/components/FilterPanel.tsx
+++ b/lib/components/FilterPanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, Dispatch, SetStateAction } from "react";
 import Button from "react-bootstrap/Button";
 import ButtonGroup from "react-bootstrap/ButtonGroup";
 import Card from "react-bootstrap/Card";
@@ -13,7 +13,7 @@ import RemoveAllModal from "./RemoveAllModal";
 
 interface FilterPanelProps extends DataProps {
   filterList: FilterConfig[];
-  setFilterList: (value: FilterConfig[]) => void;
+  setFilterList: Dispatch<SetStateAction<FilterConfig[]>>;
   filterFieldOptions: string[];
   disableLookups?: boolean;
 }
@@ -82,8 +82,8 @@ function FilterPanel(props: FilterPanelProps) {
 
   const handleFilterAdd = (index: number) => {
     setEditMode(false);
-    props.setFilterList([
-      ...props.filterList.slice(0, index),
+    props.setFilterList((prevState) => [
+      ...prevState.slice(0, index),
       {
         key: generateKey(),
         type: "",
@@ -91,14 +91,16 @@ function FilterPanel(props: FilterPanelProps) {
         lookup: "",
         value: "",
       },
-      ...props.filterList.slice(index),
+      ...prevState.slice(index),
     ]);
   };
 
   const handleFilterRemove = (index: number) => {
-    const list = [...props.filterList];
-    list.splice(index, 1);
-    props.setFilterList(list);
+    props.setFilterList((prevState) => {
+      const updatedList = [...prevState];
+      updatedList.splice(index, 1);
+      return updatedList;
+    });
   };
 
   const handleFilterRemoveAll = () => {
@@ -139,7 +141,7 @@ function FilterPanel(props: FilterPanelProps) {
         {editMode ? (
           <Filter
             {...props}
-            key={editFilter.key}
+            filter={editFilter}
             index={editIndex}
             fieldList={props.filterFieldOptions}
             setEditMode={setEditMode}

--- a/lib/components/FilterPanel.tsx
+++ b/lib/components/FilterPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, Dispatch, SetStateAction } from "react";
+import { useState } from "react";
 import Button from "react-bootstrap/Button";
 import ButtonGroup from "react-bootstrap/ButtonGroup";
 import Card from "react-bootstrap/Card";
@@ -13,7 +13,7 @@ import RemoveAllModal from "./RemoveAllModal";
 
 interface FilterPanelProps extends DataProps {
   filterList: FilterConfig[];
-  setFilterList: Dispatch<SetStateAction<FilterConfig[]>>;
+  setFilterList: (filters: FilterConfig[]) => void;
   filterFieldOptions: string[];
   disableLookups?: boolean;
 }
@@ -82,8 +82,8 @@ function FilterPanel(props: FilterPanelProps) {
 
   const handleFilterAdd = (index: number) => {
     setEditMode(false);
-    props.setFilterList((prevState) => [
-      ...prevState.slice(0, index),
+    props.setFilterList([
+      ...props.filterList.slice(0, index),
       {
         key: generateKey(),
         type: "",
@@ -91,16 +91,14 @@ function FilterPanel(props: FilterPanelProps) {
         lookup: "",
         value: "",
       },
-      ...prevState.slice(index),
+      ...props.filterList.slice(index),
     ]);
   };
 
   const handleFilterRemove = (index: number) => {
-    props.setFilterList((prevState) => {
-      const updatedList = [...prevState];
-      updatedList.splice(index, 1);
-      return updatedList;
-    });
+    const updatedList = [...props.filterList];
+    updatedList.splice(index, 1);
+    props.setFilterList(updatedList);
   };
 
   const handleFilterRemoveAll = () => {

--- a/lib/components/Resizer.tsx
+++ b/lib/components/Resizer.tsx
@@ -1,0 +1,65 @@
+import { useCallback, useEffect, useState } from "react";
+
+interface ResizerProps {
+  defaultWidth: number;
+  minWidth: number;
+  maxWidth: number;
+  setWidth: (width: number) => void;
+}
+
+export default function Resizer(props: ResizerProps) {
+  const [isResizing, setIsResizing] = useState(false);
+
+  const handleMouseDown = (e: React.MouseEvent) => {
+    e.preventDefault();
+    setIsResizing(true);
+  };
+
+  const handleMouseUp = () => setIsResizing(false);
+
+  const handleMouseMove = useCallback(
+    (e: MouseEvent) => {
+      if (!isResizing) return;
+
+      const newWidth = e.clientX;
+      if (newWidth >= props.minWidth && newWidth <= props.maxWidth) {
+        props.setWidth(newWidth);
+      }
+    },
+    [isResizing, props]
+  );
+
+  // Reset to default width
+  const handleDoubleClick = () => props.setWidth(props.defaultWidth);
+
+  // Add/remove event listeners when user starts/stops resizing
+  useEffect(() => {
+    if (isResizing) {
+      document.addEventListener("mousemove", handleMouseMove);
+      document.addEventListener("mouseup", handleMouseUp);
+      document.body.style.cursor = "col-resize";
+      document.body.style.userSelect = "none";
+    } else {
+      document.removeEventListener("mousemove", handleMouseMove);
+      document.removeEventListener("mouseup", handleMouseUp);
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+    }
+
+    // Cleanup function runs when component unmounts or dependencies change
+    return () => {
+      document.removeEventListener("mousemove", handleMouseMove);
+      document.removeEventListener("mouseup", handleMouseUp);
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+    };
+  }, [isResizing, handleMouseMove]);
+
+  return (
+    <div
+      className="resizer"
+      onMouseDown={handleMouseDown}
+      onDoubleClick={handleDoubleClick}
+    />
+  );
+}

--- a/lib/components/Table.tsx
+++ b/lib/components/Table.tsx
@@ -629,7 +629,6 @@ function ServerPaginatedTable(props: ServerPaginatedTableProps) {
       setLoading(true);
       const search = new URLSearchParams(params);
       search.set("page", serverPage.toString());
-      search.set("page_size", resultsPageSize.toString());
       search.delete("cursor");
 
       props

--- a/lib/components/Table.tsx
+++ b/lib/components/Table.tsx
@@ -278,6 +278,7 @@ function TableOptions(props: TableOptionsProps) {
     let search: URLSearchParams | null = new URLSearchParams(
       props.searchParameters
     );
+    search.delete("page_size"); // Remove page_size from search parameters
 
     // Fetch pages of data until the 'next' field is not present
     while (search instanceof URLSearchParams) {

--- a/lib/interfaces.ts
+++ b/lib/interfaces.ts
@@ -33,6 +33,7 @@ export interface IDProps extends DataProps {
 }
 
 export interface ResultsProps extends DataProps {
+  defaultFields: string[];
   title: string;
   commandBase: string;
   searchPath: string;

--- a/lib/pages/Results.tsx
+++ b/lib/pages/Results.tsx
@@ -191,55 +191,62 @@ function Results(props: ResultsProps) {
       />
       <Stack direction="horizontal" className="h-100">
         {!sidebarCollapsed && (
-          <div
-            className="h-100"
-            style={{
-              position: "relative",
-              width: sidebarWidth,
-              minWidth: sidebarWidth,
-              paddingRight: "10px",
-            }}
-          >
-            <Container fluid className="h-100 g-0">
-              <Stack gap={2} className="h-100">
-                <SearchBar
-                  {...props}
-                  placeholder={`Search ${props.title.toLowerCase()}...`}
-                  searchInput={searchInput}
-                  setSearchInput={setSearchInput}
-                  handleSearch={handleSearch}
-                />
-                <Stack gap={2} className="h-100 overflow-y-hidden">
-                  <FilterPanel
-                    {...props}
-                    filterList={filterList}
-                    setFilterList={setFilterList}
-                    filterFieldOptions={filterOptions}
-                  />
-                  <SummarisePanel
-                    {...props}
-                    summariseList={summariseList}
-                    setSummariseList={setSummariseList}
-                    filterFieldOptions={filterOptions}
-                  />
-                  <CopyToClipboardButton
-                    size="sm"
-                    variant="dark"
-                    title="Copy CLI Command"
-                    onClick={handleCopyCLICommand}
-                    showTitle
-                  />
-                </Stack>
-              </Stack>
-            </Container>
+          <>
             <div
-              className="resizer"
-              onMouseDown={handleMouseDown}
-              onDoubleClick={handleDoubleClick}
+              className="h-100"
+              style={{
+                position: "relative",
+                width: sidebarWidth,
+                minWidth: sidebarWidth,
+                paddingRight: "10px",
+              }}
+            >
+              <Container fluid className="h-100 g-0">
+                <Stack gap={2} className="h-100">
+                  <SearchBar
+                    {...props}
+                    placeholder={`Search ${props.title.toLowerCase()}...`}
+                    searchInput={searchInput}
+                    setSearchInput={setSearchInput}
+                    handleSearch={handleSearch}
+                  />
+                  <Stack gap={2} className="h-100 overflow-y-hidden">
+                    <FilterPanel
+                      {...props}
+                      filterList={filterList}
+                      setFilterList={setFilterList}
+                      filterFieldOptions={filterOptions}
+                    />
+                    <SummarisePanel
+                      {...props}
+                      summariseList={summariseList}
+                      setSummariseList={setSummariseList}
+                      filterFieldOptions={filterOptions}
+                    />
+                    <CopyToClipboardButton
+                      size="sm"
+                      variant="dark"
+                      title="Copy CLI Command"
+                      onClick={handleCopyCLICommand}
+                      showTitle
+                    />
+                  </Stack>
+                </Stack>
+              </Container>
+              <div
+                className="resizer"
+                onMouseDown={handleMouseDown}
+                onDoubleClick={handleDoubleClick}
+              />
+            </div>
+            <div
+              style={{
+                paddingLeft: "10px",
+              }}
             />
-          </div>
+          </>
         )}
-        <div className="h-100" style={{ flex: 1, paddingLeft: "10px" }}>
+        <div className="h-100" style={{ flex: 1 }}>
           <Container fluid className="h-100 g-0">
             <ResultsPanel
               {...props}

--- a/lib/pages/Results.tsx
+++ b/lib/pages/Results.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import Container from "react-bootstrap/Container";
 import Stack from "react-bootstrap/Stack";
 import { useResultsQuery } from "../api";
@@ -12,6 +12,7 @@ import { formatFilters } from "../utils/functions";
 import { useDebouncedValue } from "../utils/hooks";
 import ColumnsModal from "../components/ColumnsModal";
 import { CopyToClipboardButton } from "../components/Buttons";
+import Resizer from "../components/Resizer";
 
 function Results(props: ResultsProps) {
   // TODO: Currently duplicate queries made on initialisation
@@ -28,12 +29,9 @@ function Results(props: ResultsProps) {
   );
   const [columnsModalShow, setColumnsModalShow] = useState(false);
 
-  const defaultWidth = 300; // Default sidebar width
-  const minWidth = 220; // Minimum width for the sidebar
-  const maxWidth = 600; // Maximum width for the sidebar
+  const defaultWidth = 300;
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [sidebarWidth, setSidebarWidth] = useState(defaultWidth);
-  const [isResizing, setIsResizing] = useState(false);
 
   const filterOptions = useMemo(
     () =>
@@ -130,55 +128,6 @@ function Results(props: ResultsProps) {
     navigator.clipboard.writeText(command);
   };
 
-  // Mouse handlers for resizing the sidebar
-  const handleMouseDown = (e: React.MouseEvent) => {
-    e.preventDefault();
-    setIsResizing(true);
-  };
-
-  const handleMouseUp = () => {
-    setIsResizing(false);
-  };
-
-  const handleMouseMove = useCallback(
-    (e: MouseEvent) => {
-      if (!isResizing) return;
-
-      const newWidth = e.clientX;
-      if (newWidth >= minWidth && newWidth <= maxWidth) {
-        setSidebarWidth(newWidth);
-      }
-    },
-    [isResizing]
-  );
-
-  const handleDoubleClick = () => {
-    setSidebarWidth(defaultWidth); // Reset to default width
-  };
-
-  // Add/remove event listeners when user starts/stops resizing
-  useEffect(() => {
-    if (isResizing) {
-      document.addEventListener("mousemove", handleMouseMove);
-      document.addEventListener("mouseup", handleMouseUp);
-      document.body.style.cursor = "col-resize";
-      document.body.style.userSelect = "none";
-    } else {
-      document.removeEventListener("mousemove", handleMouseMove);
-      document.removeEventListener("mouseup", handleMouseUp);
-      document.body.style.cursor = "";
-      document.body.style.userSelect = "";
-    }
-
-    // Cleanup function runs when component unmounts or dependencies change
-    return () => {
-      document.removeEventListener("mousemove", handleMouseMove);
-      document.removeEventListener("mouseup", handleMouseUp);
-      document.body.style.cursor = "";
-      document.body.style.userSelect = "";
-    };
-  }, [isResizing, handleMouseMove]);
-
   return (
     <Container fluid className="g-0 h-100">
       <ColumnsModal
@@ -233,10 +182,11 @@ function Results(props: ResultsProps) {
                   </Stack>
                 </Stack>
               </Container>
-              <div
-                className="resizer"
-                onMouseDown={handleMouseDown}
-                onDoubleClick={handleDoubleClick}
+              <Resizer
+                defaultWidth={defaultWidth}
+                minWidth={220}
+                maxWidth={600}
+                setWidth={setSidebarWidth}
               />
             </div>
             <div

--- a/lib/pages/Results.tsx
+++ b/lib/pages/Results.tsx
@@ -18,7 +18,11 @@ function Results(props: ResultsProps) {
   const [searchInput, setSearchInput] = useState("");
   const [filterList, setFilterList] = useState([] as FilterConfig[]);
   const [summariseList, setSummariseList] = useState(new Array<string>());
-  const [columnList, setColumnList] = useState<Field[]>([]);
+  const [columnList, setColumnList] = useState<Field[]>(
+    Array.from(props.fields.entries())
+      .filter(([, field]) => props.defaultFields.includes(field.code))
+      .map(([, field]) => field)
+  );
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [columnsModalShow, setColumnsModalShow] = useState(false);
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -126,6 +126,7 @@ export type Fields = {
   name: string;
   description: string;
   fields: Record<string, Field>;
+  default_gui_fields: string[];
 };
 
 export type FilterConfig = {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -126,7 +126,7 @@ export type Fields = {
   name: string;
   description: string;
   fields: Record<string, Field>;
-  default_gui_fields: string[];
+  default_fields: string[];
 };
 
 export type FilterConfig = {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -126,7 +126,7 @@ export type Fields = {
   name: string;
   description: string;
   fields: Record<string, Field>;
-  default_fields: string[];
+  default_fields?: string[];
 };
 
 export type FilterConfig = {

--- a/lib/utils/functions.ts
+++ b/lib/utils/functions.ts
@@ -19,7 +19,9 @@ function getDefaultFileNamePrefix(project: string, searchParameters: string) {
   // removes special characters, and truncates to 50 characters
   return [["", project]]
     .concat(Array.from(new URLSearchParams(searchParameters).entries()))
-    .filter(([parameter]) => !["include", "exclude"].includes(parameter))
+    .filter(
+      ([parameter]) => !["include", "exclude", "page_size"].includes(parameter)
+    )
     .map(([, value]) =>
       value
         // Split on all groups of spaces and commas


### PR DESCRIPTION
- Default fields can now be set on initialisation from a optional `default_fields` key returned by the API from the `fields` endpoint.
- Added `Resizer` component for much more intuitive sidebar resizing functionality.
- Removed `searchParameters` state variable and replaced usage with debounced `debouncedSearchParams`, leading to simpler query state management.
- Fixed issues with uncontrolled state (due to accessing invalid array indexes) in `Filter` component. 