### PR TITLE
Bug fix: calculate resize slider position from widget container's position, not absolute viewport position

### DIFF
--- a/lib/components/Resizer.tsx
+++ b/lib/components/Resizer.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 interface ResizerProps {
   defaultWidth: number;
@@ -9,6 +9,7 @@ interface ResizerProps {
 
 export default function Resizer(props: ResizerProps) {
   const [isResizing, setIsResizing] = useState(false);
+  const resizerRef = useRef<HTMLDivElement>(null);
 
   const handleMouseDown = (e: React.MouseEvent) => {
     e.preventDefault();
@@ -21,7 +22,13 @@ export default function Resizer(props: ResizerProps) {
     (e: MouseEvent) => {
       if (!isResizing) return;
 
-      const newWidth = e.clientX;
+      // Get the sidebar container (parent of the resizer)
+      const sidebarContainer = resizerRef.current?.parentElement;
+      if (!sidebarContainer) return;
+
+      const containerRect = sidebarContainer.getBoundingClientRect();
+      const newWidth = e.clientX - containerRect.left;
+
       if (newWidth >= props.minWidth && newWidth <= props.maxWidth) {
         props.setWidth(newWidth);
       }
@@ -57,6 +64,7 @@ export default function Resizer(props: ResizerProps) {
 
   return (
     <div
+      ref={resizerRef}
       className="resizer"
       onMouseDown={handleMouseDown}
       onDoubleClick={handleDoubleClick}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "climb-onyx-gui",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "climb-onyx-gui",
-      "version": "0.15.0",
+      "version": "0.15.1",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@ag-grid-community/client-side-row-model": "^32.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "climb-onyx-gui",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Onyx Graphical User Interface",
   "keywords": [
     "gui",


### PR DESCRIPTION
- When the Onyx GUI is embedded as a widget inside Jupyterlab, we need to calculate `Resizer` position based relative to its parent container, not the browser viewport.