### PR TITLE
Persistent key-value storage interface

### DIFF
--- a/lib/Onyx.tsx
+++ b/lib/Onyx.tsx
@@ -57,25 +57,33 @@ function ProjectPage(props: ProjectPageProps) {
   const { description, fields, defaultFields } = useFieldsInfo(fieldsResponse);
 
   // Get project analyses information
-  const { data: analysisFieldsResponse } = useAnalysisFieldsQuery(props);
+  const {
+    isFetching: isAnalysisFetching,
+    error: analysisError,
+    data: analysisFieldsResponse,
+  } = useAnalysisFieldsQuery(props);
   const { fields: analysisFields, defaultFields: defaultAnalysisFields } =
     useFieldsInfo(analysisFieldsResponse);
 
   return (
-    <QueryHandler isFetching={isFetching} error={error} data={fieldsResponse}>
-      <Tab.Container
-        activeKey={props.tabState.tabKey}
-        mountOnEnter
-        transition={false}
-      >
-        <Tab.Content className="h-100">
-          <Tab.Pane eventKey={OnyxTabKeys.USER} className="h-100">
-            <User {...props} />
-          </Tab.Pane>
-          <Tab.Pane eventKey={OnyxTabKeys.SITE} className="h-100">
-            <Site {...props} />
-          </Tab.Pane>
-          <Tab.Pane eventKey={OnyxTabKeys.RECORDS} className="h-100">
+    <Tab.Container
+      activeKey={props.tabState.tabKey}
+      mountOnEnter
+      transition={false}
+    >
+      <Tab.Content className="h-100">
+        <Tab.Pane eventKey={OnyxTabKeys.USER} className="h-100">
+          <User {...props} />
+        </Tab.Pane>
+        <Tab.Pane eventKey={OnyxTabKeys.SITE} className="h-100">
+          <Site {...props} />
+        </Tab.Pane>
+        <Tab.Pane eventKey={OnyxTabKeys.RECORDS} className="h-100">
+          <QueryHandler
+            isFetching={isFetching}
+            error={error}
+            data={fieldsResponse}
+          >
             <Tab.Container
               activeKey={props.tabState.recordTabKey}
               transition={false}
@@ -107,8 +115,14 @@ function ProjectPage(props: ProjectPageProps) {
                 </Tab.Pane>
               </Tab.Content>
             </Tab.Container>
-          </Tab.Pane>
-          <Tab.Pane eventKey={OnyxTabKeys.ANALYSES} className="h-100">
+          </QueryHandler>
+        </Tab.Pane>
+        <Tab.Pane eventKey={OnyxTabKeys.ANALYSES} className="h-100">
+          <QueryHandler
+            isFetching={isAnalysisFetching}
+            error={analysisError}
+            data={analysisFieldsResponse}
+          >
             <Tab.Container
               activeKey={props.tabState.analysisTabKey}
               transition={false}
@@ -140,17 +154,13 @@ function ProjectPage(props: ProjectPageProps) {
                 </Tab.Pane>
               </Tab.Content>
             </Tab.Container>
-          </Tab.Pane>
-          <Tab.Pane eventKey={OnyxTabKeys.GRAPHS} className="h-100">
-            <Graphs
-              {...props}
-              fields={fields}
-              projectDescription={description}
-            />
-          </Tab.Pane>
-        </Tab.Content>
-      </Tab.Container>
-    </QueryHandler>
+          </QueryHandler>
+        </Tab.Pane>
+        <Tab.Pane eventKey={OnyxTabKeys.GRAPHS} className="h-100">
+          <Graphs {...props} fields={fields} projectDescription={description} />
+        </Tab.Pane>
+      </Tab.Content>
+    </Tab.Container>
   );
 }
 

--- a/lib/Onyx.tsx
+++ b/lib/Onyx.tsx
@@ -87,6 +87,7 @@ function ProjectPage(props: ProjectPageProps) {
                     fields={fields}
                     defaultFields={defaultFields}
                     projectDescription={description}
+                    objectType="record"
                     title="Records"
                     commandBase={`onyx filter ${props.project.code}`}
                     searchPath={`projects/${props.project.code}`}
@@ -120,6 +121,7 @@ function ProjectPage(props: ProjectPageProps) {
                     fields={analysisFields}
                     defaultFields={defaultAnalysisFields}
                     projectDescription={description}
+                    objectType="analysis"
                     title="Analyses"
                     commandBase={`onyx filter-analysis ${props.project.code}`}
                     searchPath={`projects/${props.project.code}/analysis`}

--- a/lib/Onyx.tsx
+++ b/lib/Onyx.tsx
@@ -87,7 +87,6 @@ function ProjectPage(props: ProjectPageProps) {
                     fields={fields}
                     defaultFields={defaultFields}
                     projectDescription={description}
-                    objectType="record"
                     title="Records"
                     commandBase={`onyx filter ${props.project.code}`}
                     searchPath={`projects/${props.project.code}`}
@@ -121,7 +120,6 @@ function ProjectPage(props: ProjectPageProps) {
                     fields={analysisFields}
                     defaultFields={defaultAnalysisFields}
                     projectDescription={description}
-                    objectType="analysis"
                     title="Analyses"
                     commandBase={`onyx filter-analysis ${props.project.code}`}
                     searchPath={`projects/${props.project.code}/analysis`}

--- a/lib/Onyx.tsx
+++ b/lib/Onyx.tsx
@@ -34,8 +34,9 @@ import {
   TabState,
   Themes,
   RecentlyViewed,
+  ObjectType,
 } from "./types";
-import { useDelayedValue } from "./utils/hooks";
+import { useDelayedValue, usePersistedState } from "./utils/hooks";
 
 import "@fontsource/ibm-plex-sans";
 import "./Onyx.css";
@@ -207,9 +208,19 @@ function App(props: OnyxProps) {
   };
 
   // Project state
-  const [project, setProject] = useState<Project>();
-  const [tabState, setTabState] = useState<TabState>(defaultTabState);
-  const [recentlyViewed, setRecentlyViewed] = useState<RecentlyViewed[]>([]);
+  const [project, setProject] = usePersistedState<Project | undefined>(
+    props,
+    "project",
+    undefined
+  );
+  const [tabState, setTabState] = usePersistedState<TabState>(
+    props,
+    "tabState",
+    defaultTabState
+  );
+  const [recentlyViewed, setRecentlyViewed] = usePersistedState<
+    RecentlyViewed[]
+  >(props, "recentlyViewed", []);
 
   // Clear parameters when project changes
   const handleProjectChange = (p: Project) => {
@@ -266,10 +277,10 @@ function App(props: OnyxProps) {
     if (!project && projects.length > 0) {
       setProject(projects[0]);
     }
-  }, [project, projects]);
+  }, [project, projects, setProject]);
 
   const handleRecentlyViewed = useCallback(
-    (ID: string, handleShowID: (id: string) => void) => {
+    (objectType: ObjectType, ID: string) => {
       setRecentlyViewed((prevState) => {
         const updatedList = [...prevState];
 
@@ -279,16 +290,16 @@ function App(props: OnyxProps) {
 
         // Add new item to the front of the list
         updatedList.unshift({
+          objectType: objectType,
           ID: ID,
-          timestamp: new Date(),
-          handleShowID: handleShowID,
+          timestamp: new Date().toString(),
         });
 
         // Limit to 10 recently viewed items
         return updatedList.slice(0, 10);
       });
     },
-    []
+    [setRecentlyViewed]
   );
 
   // https://react.dev/reference/react/useCallback#skipping-re-rendering-of-components
@@ -304,9 +315,9 @@ function App(props: OnyxProps) {
         recordDataPanelTabKey: DataPanelTabKeys.DETAILS,
         recordID: climbID,
       }));
-      handleRecentlyViewed(climbID, handleProjectRecordShow);
+      handleRecentlyViewed("record", climbID);
     },
-    [handleRecentlyViewed]
+    [handleRecentlyViewed, setTabState]
   );
 
   const handleProjectRecordHide = useCallback(() => {
@@ -315,7 +326,7 @@ function App(props: OnyxProps) {
       tabKey: OnyxTabKeys.RECORDS,
       recordTabKey: RecordTabKeys.LIST,
     }));
-  }, []);
+  }, [setTabState]);
 
   const handleAnalysisShow = useCallback(
     (analysisID: string) => {
@@ -327,9 +338,9 @@ function App(props: OnyxProps) {
         analysisDataPanelTabKey: DataPanelTabKeys.DETAILS,
         analysisID: analysisID,
       }));
-      handleRecentlyViewed(analysisID, handleAnalysisShow);
+      handleRecentlyViewed("analysis", analysisID);
     },
-    [handleRecentlyViewed]
+    [handleRecentlyViewed, setTabState]
   );
 
   const handleAnalysisHide = useCallback(() => {
@@ -338,7 +349,7 @@ function App(props: OnyxProps) {
       tabKey: OnyxTabKeys.ANALYSES,
       analysisTabKey: AnalysisTabKeys.LIST,
     }));
-  }, []);
+  }, [setTabState]);
 
   return (
     <div className="Onyx h-100">

--- a/lib/components/ColumnsModal.tsx
+++ b/lib/components/ColumnsModal.tsx
@@ -14,14 +14,16 @@ interface ColumnsModalProps extends DataProps {
   show: boolean;
   onHide: () => void;
   columns: Field[];
-  activeColumns: Field[];
-  setActiveColumns: (value: Field[]) => void;
+  defaultColumns: string[];
+  activeColumns: string[];
+  setActiveColumns: (value: string[]) => void;
 }
 
 function ColumnsModal(props: ColumnsModalProps) {
   const [selectAll, setSelectAll] = useState<boolean>(false);
   const [activeColumns, setActiveColumns] = useState<Set<string>>(new Set());
   const [search, setSearch] = useState<string>("");
+
   const debouncedSearch = useDebouncedValue(search.toLowerCase(), 200);
   const filteredColumns = useMemo(
     () =>
@@ -32,6 +34,7 @@ function ColumnsModal(props: ColumnsModalProps) {
       ),
     [props.columns, debouncedSearch]
   );
+
   const activeColumnsMessage = useMemo(() => {
     return `${activeColumns.size} column${
       activeColumns.size !== 1 ? "s" : ""
@@ -40,7 +43,7 @@ function ColumnsModal(props: ColumnsModalProps) {
 
   // Update active columns when props.activeColumns changes
   useEffect(() => {
-    setActiveColumns(new Set(props.activeColumns.map((column) => column.code)));
+    setActiveColumns(new Set(props.activeColumns));
   }, [props.activeColumns]);
 
   const handleSearchChange = (search: string) => {
@@ -69,9 +72,7 @@ function ColumnsModal(props: ColumnsModalProps) {
 
   // Apply the changes to active columns, then close the modal
   const handleApply = () => {
-    props.setActiveColumns(
-      props.columns.filter((column) => activeColumns.has(column.code))
-    );
+    props.setActiveColumns(Array.from(activeColumns));
     props.onHide();
   };
 
@@ -132,6 +133,17 @@ function ColumnsModal(props: ColumnsModalProps) {
         </Stack>
       </Modal.Body>
       <Modal.Footer>
+        <Button
+          className="me-auto"
+          variant="dark"
+          onClick={() => {
+            setActiveColumns(new Set(props.defaultColumns));
+            setSelectAll(false);
+            setSearch("");
+          }}
+        >
+          Reset to Defaults
+        </Button>
         <span className="text-muted px-2">{activeColumnsMessage}</span>
         <Button variant="dark" onClick={props.onHide}>
           Cancel

--- a/lib/components/Header.tsx
+++ b/lib/components/Header.tsx
@@ -17,6 +17,7 @@ import { PageProps } from "../interfaces";
 import {
   AnalysisTabKeys,
   DarkModeColours,
+  ObjectType,
   OnyxTabKeys,
   Profile,
   Project,
@@ -36,10 +37,7 @@ interface HeaderProps extends PageProps {
   handleAnalysisShow: (analysisID: string) => void;
   handleProjectRecordHide: () => void;
   handleAnalysisHide: () => void;
-  handleRecentlyViewed: (
-    ID: string,
-    handleShowID: (ID: string) => void
-  ) => void;
+  handleRecentlyViewed: (objectType: ObjectType, ID: string) => void;
 }
 
 function HeaderText({
@@ -112,20 +110,14 @@ function Header(props: HeaderProps) {
       tabKey === OnyxTabKeys.RECORDS &&
       props.tabState.recordTabKey === RecordTabKeys.DETAIL
     ) {
-      props.handleRecentlyViewed(
-        props.tabState.recordID,
-        props.handleProjectRecordShow
-      );
+      props.handleRecentlyViewed("record", props.tabState.recordID);
     }
 
     if (
       tabKey === OnyxTabKeys.ANALYSES &&
       props.tabState.analysisTabKey === AnalysisTabKeys.DETAIL
     ) {
-      props.handleRecentlyViewed(
-        props.tabState.analysisID,
-        props.handleAnalysisShow
-      );
+      props.handleRecentlyViewed("analysis", props.tabState.analysisID);
     }
   };
 
@@ -262,7 +254,12 @@ function Header(props: HeaderProps) {
                     <Dropdown.Item
                       key={item.ID}
                       title={item.ID + " - " + item.timestamp.toLocaleString()}
-                      onClick={() => item.handleShowID(item.ID)}
+                      onClick={() => {
+                        if (item.objectType === "record")
+                          props.handleProjectRecordShow(item.ID);
+                        else if (item.objectType === "analysis")
+                          props.handleAnalysisShow(item.ID);
+                      }}
                     >
                       {item.ID} -{" "}
                       <span className="text-muted">

--- a/lib/interfaces.ts
+++ b/lib/interfaces.ts
@@ -6,6 +6,8 @@ export interface OnyxProps {
   s3PathHandler: (path: string) => Promise<void>;
   fileWriter: (path: string, content: string) => Promise<void>;
   extVersion: string;
+  getItem?: (key: string) => unknown;
+  setItem?: (key: string, value: unknown) => void;
 }
 
 export interface PageProps extends OnyxProps {

--- a/lib/interfaces.ts
+++ b/lib/interfaces.ts
@@ -1,5 +1,5 @@
 import { Dispatch, SetStateAction } from "react";
-import { ExportStatus, ObjectType, TabState, Project, Field } from "./types";
+import { ExportStatus, TabState, Project, Field } from "./types";
 
 export interface OnyxProps {
   httpPathHandler: (path: string) => Promise<Response>;
@@ -36,7 +36,6 @@ export interface IDProps extends DataProps {
 
 export interface ResultsProps extends DataProps {
   defaultFields: string[];
-  objectType: ObjectType;
   title: string;
   commandBase: string;
   searchPath: string;

--- a/lib/interfaces.ts
+++ b/lib/interfaces.ts
@@ -1,5 +1,5 @@
 import { Dispatch, SetStateAction } from "react";
-import { ExportStatus, Project, Field, TabState } from "./types";
+import { ExportStatus, ObjectType, TabState, Project, Field } from "./types";
 
 export interface OnyxProps {
   httpPathHandler: (path: string) => Promise<Response>;
@@ -36,6 +36,7 @@ export interface IDProps extends DataProps {
 
 export interface ResultsProps extends DataProps {
   defaultFields: string[];
+  objectType: ObjectType;
   title: string;
   commandBase: string;
   searchPath: string;

--- a/lib/pages/Graphs.tsx
+++ b/lib/pages/Graphs.tsx
@@ -396,8 +396,16 @@ function Graphs(props: DataProps) {
   const [graphConfigList, setGraphConfigList] = usePersistedState<
     GraphConfig[]
   >(props, "graphConfigs", defaultGraphConfig());
-  const [viewMode, setViewMode] = useState<"list" | "grid">("list");
-  const [showOptions, setShowOptions] = useState(true);
+  const [viewMode, setViewMode] = usePersistedState<"list" | "grid">(
+    props,
+    "graphViewMode",
+    "list"
+  );
+  const [showOptions, setShowOptions] = usePersistedState<boolean>(
+    props,
+    "graphShowOptions",
+    true
+  );
   const [refresh, setRefresh] = useState<number | null>(null);
   const [removeAllModalShow, setRemoveAllModalShow] = useState(false);
 

--- a/lib/pages/Graphs.tsx
+++ b/lib/pages/Graphs.tsx
@@ -43,6 +43,7 @@ import {
 import { generateKey } from "../utils/functions";
 import RemoveAllModal from "../components/RemoveAllModal";
 import { useFieldDescriptions } from "../api/hooks";
+import { usePersistedState } from "../utils/hooks";
 
 interface GraphPanelProps extends DataProps {
   graphConfig: GraphConfig;
@@ -104,7 +105,7 @@ function GraphPanelTitle(props: GraphPanelProps) {
             props.graphConfig.filters
               .filter((filter) => filter.field)
               .map((filter) => (
-                <span>
+                <span key={filter.key}>
                   , filtered by {filter.field}:{" "}
                   <span className="onyx-text-pink font-monospace">
                     {filter.value}
@@ -392,14 +393,17 @@ function Graphs(props: DataProps) {
       },
     ] as GraphConfig[];
 
-  const [graphConfigList, setGraphConfigList] = useState(defaultGraphConfig());
-  const listFieldOptions = Array.from(props.fields.entries())
-    .filter(([, field]) => field.actions.includes("list"))
-    .map(([field]) => field);
+  const [graphConfigList, setGraphConfigList] = usePersistedState<
+    GraphConfig[]
+  >(props, "graphConfigs", defaultGraphConfig());
   const [viewMode, setViewMode] = useState<"list" | "grid">("list");
   const [showOptions, setShowOptions] = useState(true);
   const [refresh, setRefresh] = useState<number | null>(null);
   const [removeAllModalShow, setRemoveAllModalShow] = useState(false);
+
+  const listFieldOptions = Array.from(props.fields.entries())
+    .filter(([, field]) => field.actions.includes("list"))
+    .map(([field]) => field);
 
   const handleRefresh = () => {
     setRefresh(refresh ? 0 : 1);

--- a/lib/pages/Graphs.tsx
+++ b/lib/pages/Graphs.tsx
@@ -395,15 +395,15 @@ function Graphs(props: DataProps) {
 
   const [graphConfigList, setGraphConfigList] = usePersistedState<
     GraphConfig[]
-  >(props, "graphConfigs", defaultGraphConfig());
+  >(props, `${props.project.code}GraphConfigs`, defaultGraphConfig());
   const [viewMode, setViewMode] = usePersistedState<"list" | "grid">(
     props,
-    "graphViewMode",
+    `${props.project.code}GraphViewMode`,
     "list"
   );
   const [showOptions, setShowOptions] = usePersistedState<boolean>(
     props,
-    "graphShowOptions",
+    `${props.project.code}GraphShowOptions`,
     true
   );
   const [refresh, setRefresh] = useState<number | null>(null);

--- a/lib/pages/Results.tsx
+++ b/lib/pages/Results.tsx
@@ -9,7 +9,7 @@ import SummarisePanel from "../components/SummarisePanel";
 import { ResultsProps } from "../interfaces";
 import { FilterConfig, Field } from "../types";
 import { formatFilters } from "../utils/functions";
-import { useDebouncedValue } from "../utils/hooks";
+import { useDebouncedValue, usePersistedState } from "../utils/hooks";
 import ColumnsModal from "../components/ColumnsModal";
 import { CopyToClipboardButton } from "../components/Buttons";
 import Resizer from "../components/Resizer";
@@ -17,8 +17,16 @@ import Resizer from "../components/Resizer";
 function Results(props: ResultsProps) {
   const pageSize = 100; // Pagination page size
   const [searchInput, setSearchInput] = useState("");
-  const [filterList, setFilterList] = useState([] as FilterConfig[]);
-  const [summariseList, setSummariseList] = useState(new Array<string>());
+  const [filterList, setFilterList] = usePersistedState<FilterConfig[]>(
+    props,
+    `${props.objectType}FilterConfigs`,
+    []
+  );
+  const [summariseList, setSummariseList] = usePersistedState<Array<string>>(
+    props,
+    `${props.objectType}SummariseConfigs`,
+    []
+  );
   const [includeList, setIncludeList] = useState<Field[]>(
     Array.from(props.fields.entries())
       .filter(([, field]) => props.defaultFields.includes(field.code))

--- a/lib/pages/Results.tsx
+++ b/lib/pages/Results.tsx
@@ -16,7 +16,11 @@ import Resizer from "../components/Resizer";
 
 function Results(props: ResultsProps) {
   const pageSize = 100; // Pagination page size
-  const [searchInput, setSearchInput] = useState("");
+  const [searchInput, setSearchInput] = usePersistedState(
+    props,
+    `${props.objectType}SearchInput`,
+    ""
+  );
   const [filterList, setFilterList] = usePersistedState<FilterConfig[]>(
     props,
     `${props.objectType}FilterConfigs`,

--- a/lib/pages/Results.tsx
+++ b/lib/pages/Results.tsx
@@ -18,22 +18,22 @@ function Results(props: ResultsProps) {
   const pageSize = 100; // Pagination page size
   const [searchInput, setSearchInput] = usePersistedState(
     props,
-    `${props.objectType}SearchInput`,
+    `${props.project.code}${props.title}SearchInput`,
     ""
   );
   const [filterList, setFilterList] = usePersistedState<FilterConfig[]>(
     props,
-    `${props.objectType}FilterConfigs`,
+    `${props.project.code}${props.title}FilterConfigs`,
     []
   );
   const [summariseList, setSummariseList] = usePersistedState<string[]>(
     props,
-    `${props.objectType}SummariseConfigs`,
+    `${props.project.code}${props.title}SummariseConfigs`,
     []
   );
   const [includeList, setIncludeList] = usePersistedState<string[]>(
     props,
-    `${props.objectType}IncludeList`,
+    `${props.project.code}${props.title}IncludeList`,
     props.defaultFields
   );
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -61,6 +61,8 @@ export enum ExportStatus {
   ERROR,
 }
 
+export type ObjectType = "record" | "analysis";
+
 export type TabState = {
   tabKey: OnyxTabKeys;
   recordTabKey: RecordTabKeys;
@@ -74,9 +76,9 @@ export type TabState = {
 };
 
 export type RecentlyViewed = {
+  objectType: ObjectType;
   ID: string;
-  timestamp: Date;
-  handleShowID: (id: string) => void;
+  timestamp: string;
 };
 
 export type FieldType =

--- a/lib/utils/functions.ts
+++ b/lib/utils/functions.ts
@@ -72,8 +72,8 @@ function formatResponseStatus(response: Response) {
   return `${response.status} (${response.statusText})`;
 }
 
-export function formatTimeAgo(timestamp: Date): string {
-  const diffInMs = new Date().getTime() - timestamp.getTime();
+export function formatTimeAgo(timestamp: string): string {
+  const diffInMs = new Date().getTime() - new Date(timestamp).getTime();
 
   const seconds = Math.floor(diffInMs / 1000);
   const minutes = Math.floor(seconds / 60);

--- a/lib/utils/hooks.ts
+++ b/lib/utils/hooks.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { OnyxProps } from "../interfaces";
 
-export const useDebouncedValue = (inputValue: string, delay: number) => {
+export function useDebouncedValue<T>(inputValue: T, delay: number) {
   const [debouncedValue, setDebouncedValue] = useState(inputValue);
 
   useEffect(() => {
@@ -10,7 +10,7 @@ export const useDebouncedValue = (inputValue: string, delay: number) => {
   }, [inputValue, delay]);
 
   return debouncedValue;
-};
+}
 
 export const useDelayedValue = (delay?: number) => {
   const [showValue, setShowValue] = useState(false);
@@ -75,9 +75,12 @@ export function usePersistedState<T>(
     return (getItem && (getItem(key) as T)) ?? initialValue;
   });
 
+  // Use a debounced value to avoid excessive writes
+  const debouncedState = useDebouncedValue(state, 500);
+
   useEffect(() => {
-    if (setItem) setItem(key, state);
-  }, [setItem, key, state]);
+    if (setItem) setItem(key, debouncedState);
+  }, [setItem, key, debouncedState]);
 
   return [state, setState] as const;
 }

--- a/lib/utils/hooks.ts
+++ b/lib/utils/hooks.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { OnyxProps } from "../interfaces";
 
 export const useDebouncedValue = (inputValue: string, delay: number) => {
   const [debouncedValue, setDebouncedValue] = useState(inputValue);
@@ -63,3 +64,20 @@ export const useQueryRefresh = (
     );
   }, [dataUpdatedAt, errorUpdatedAt, setLastUpdated]);
 };
+
+export function usePersistedState<T>(
+  props: OnyxProps,
+  key: string,
+  initialValue: T
+) {
+  const { getItem, setItem } = props;
+  const [state, setState] = useState<T>(() => {
+    return (getItem && (getItem(key) as T)) ?? initialValue;
+  });
+
+  useEffect(() => {
+    if (setItem) setItem(key, state);
+  }, [setItem, key, state]);
+
+  return [state, setState] as const;
+}

--- a/lib/utils/hooks.ts
+++ b/lib/utils/hooks.ts
@@ -71,6 +71,8 @@ export function usePersistedState<T>(
   initialValue: T
 ) {
   const { getItem, setItem } = props;
+
+  // Initialise state with the persisted value or the initial value
   const [state, setState] = useState<T>(() => {
     return (getItem && (getItem(key) as T)) ?? initialValue;
   });
@@ -78,9 +80,17 @@ export function usePersistedState<T>(
   // Use a debounced value to avoid excessive writes
   const debouncedState = useDebouncedValue(state, 500);
 
+  // Update the persisted state when the debounced state changes
   useEffect(() => {
     if (setItem) setItem(key, debouncedState);
   }, [setItem, key, debouncedState]);
+
+  // Clear the persisted state when the component unmounts
+  useEffect(() => {
+    return () => {
+      if (setItem) setItem(key, null);
+    };
+  }, [setItem, key]);
 
   return [state, setState] as const;
 }

--- a/src/handlers.tsx
+++ b/src/handlers.tsx
@@ -2,7 +2,7 @@ function delay(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function httpPathHandler(path: string) {
+export async function httpPathHandler(path: string) {
   const domain = import.meta.env.VITE_ONYX_DOMAIN || "";
   const token = import.meta.env.VITE_ONYX_TOKEN || "";
   return fetch(domain + path, {
@@ -12,19 +12,38 @@ function httpPathHandler(path: string) {
   });
 }
 
-function s3PathHandler(path: string) {
+export async function s3PathHandler(path: string) {
   return delay(1000).then(() => {
     console.log("Opening S3 file:", path);
   });
 }
 
-function fileWriter(path: string, content: string) {
+export async function fileWriter(path: string, content: string) {
   return delay(1000).then(() => {
     console.log("Writing file:", path);
     console.log("Content:", content);
   });
 }
 
-const extVersion = import.meta.env.VITE_ONYX_VERSION || "";
+export const extVersion = import.meta.env.VITE_ONYX_VERSION || "";
 
-export { fileWriter, httpPathHandler, s3PathHandler, extVersion };
+export function getItem(key: string) {
+  try {
+    const itemKey = `onyx-${key}`;
+    const item = sessionStorage.getItem(itemKey);
+    console.log("Retrieving item from sessionStorage:", itemKey, item);
+    return item ? JSON.parse(item) : undefined;
+  } catch (error) {
+    console.error("Error reading from sessionStorage", error);
+  }
+}
+
+export function setItem(key: string, value: unknown) {
+  try {
+    const itemKey = `onyx-${key}`;
+    sessionStorage.setItem(itemKey, JSON.stringify(value));
+    console.log("Saving item to sessionStorage:", itemKey, value);
+  } catch (error) {
+    console.error("Error saving to sessionStorage", error);
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,6 +6,8 @@ import {
   httpPathHandler,
   s3PathHandler,
   extVersion,
+  getItem,
+  setItem,
 } from "./handlers.tsx";
 
 import "./font.css";
@@ -17,6 +19,8 @@ ReactDOM.render(
       s3PathHandler={s3PathHandler}
       fileWriter={fileWriter}
       extVersion={extVersion}
+      getItem={getItem}
+      setItem={setItem}
     />
   </React.StrictMode>,
   document.getElementById("root")


### PR DESCRIPTION
- The `Onyx` component can now be provided with optional `getItem` and `setItem` functions, for storing and retrieving state which we want to persist on browser tab refresh.
- A hook `usePersistedState` has been added to abstract the management with the `getItem` and `setItem` functions of state to/from the persisted storage method.
- We now have persisted selected project, tab state, filtering and graph configurations.
- The dummy storage used in development is to use `sessionStorage`, but in JupyterLab we should be able to pass in handler functions to save session data in the `.jupyterlab` file instead. 
- Updated some types e.g. `RecentlyViewed` to be serializable, i.e. by removing functions.