### PR TITLE
Results view update

### DIFF
--- a/lib/components/Resizer.tsx
+++ b/lib/components/Resizer.tsx
@@ -71,7 +71,6 @@ export default function Resizer(props: ResizerProps) {
         flexBasis: width,
         minWidth: props.minWidth,
         maxWidth: props.maxWidth,
-        flexShrink: 1,
       }}
     >
       {props.children}

--- a/lib/pages/Results.tsx
+++ b/lib/pages/Results.tsx
@@ -174,7 +174,7 @@ function Results(props: ResultsProps) {
             </Container>
           </Resizer>
         )}
-        <div className="h-100" style={{ flex: 1, minWidth: 220 }}>
+        <div className="h-100" style={{ minWidth: "50%", flex: 1 }}>
           <Container fluid className="h-100 g-0">
             <ResultsPanel
               {...props}


### PR DESCRIPTION
- Removed horizontal scroll of results page on small viewports, unless both results size of 50% and filters size of 220px cant be satisfied