### PR TITLE
`v0.17.2`

### DIFF
--- a/lib/pages/Results.tsx
+++ b/lib/pages/Results.tsx
@@ -61,7 +61,11 @@ function Results(props: ResultsProps) {
     `${props.project.code}${props.title}IncludeList`,
     props.fields.default_fields || []
   );
-  const [order, setOrder] = useState<string>("");
+  const [order, setOrder] = usePersistedState<string>(
+    props,
+    `${props.project.code}${props.title}Order`,
+    props.fields.fields_map.has("published_date") ? "-published_date" : ""
+  );
   const [page, setPage] = useState<number>(1);
   const pageSize = 50; // Pagination page size
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "climb-onyx-gui",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "climb-onyx-gui",
-      "version": "0.17.1",
+      "version": "0.17.2",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@ag-grid-community/client-side-row-model": "^32.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "climb-onyx-gui",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "description": "Onyx Graphical User Interface",
   "keywords": [
     "gui",


### PR DESCRIPTION
- Persisted table ordering for records and analyses.
- Default ordering of records and analyses by most recent `published_date`.